### PR TITLE
Add `session.save_path` as configured by ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Configurable directives:
  
 - `PHP_MAX_EXECUTION_TIME` – change the [`max_execution_time` directive](https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time) (default value: `30`)
 - `PHP_MEMORY_LIMIT` – change the [`memory_limit` directive](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) (default value: `2G`)
+- `PHP_SESSION_SAVE_PATH` – change the [`session.save_path` directive](https://www.php.net/manual/en/session.configuration.php#ini.session.save-path) (default value: *empty*)
 - `PHP_OPCACHE_ENABLE` – change the [`opcache.enable` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.enable) (default value: `1`)
 - `PHP_OPCACHE_ENABLE_CLI` – change the [`opcache.enable_cli` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.enable-cli) (default value: `0`)
 - `PHP_OPCACHE_MEMORY_CONSUPTION` – change the [`opcache.memory_consumption` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.memory-consumption) (default value: `128`)

--- a/php/Dockerfile-7.4
+++ b/php/Dockerfile-7.4
@@ -74,6 +74,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/Dockerfile-7.4-cli
+++ b/php/Dockerfile-7.4-cli
@@ -70,6 +70,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/Dockerfile-8.0
+++ b/php/Dockerfile-8.0
@@ -74,6 +74,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/Dockerfile-8.0-cli
+++ b/php/Dockerfile-8.0-cli
@@ -70,6 +70,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -75,6 +75,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -71,6 +71,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/core.ini
+++ b/php/core.ini
@@ -1,3 +1,4 @@
 date.timezone = ${TZ}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 memory_limit = ${PHP_MEMORY_LIMIT}
+session.save_path = ${PHP_SESSION_SAVE_PATH}

--- a/php/legacy/Dockerfile-5.4
+++ b/php/legacy/Dockerfile-5.4
@@ -75,6 +75,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Move Apache Document root to sub-directory `www` (PHP frameworks convention)

--- a/php/legacy/Dockerfile-5.4-cli
+++ b/php/legacy/Dockerfile-5.4-cli
@@ -71,6 +71,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Setup Devstack (install Composer)

--- a/php/legacy/Dockerfile-5.5
+++ b/php/legacy/Dockerfile-5.5
@@ -74,6 +74,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-5.5-cli
+++ b/php/legacy/Dockerfile-5.5-cli
@@ -70,6 +70,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-5.6
+++ b/php/legacy/Dockerfile-5.6
@@ -74,6 +74,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-5.6-cli
+++ b/php/legacy/Dockerfile-5.6-cli
@@ -70,6 +70,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.0
+++ b/php/legacy/Dockerfile-7.0
@@ -73,6 +73,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.0-cli
+++ b/php/legacy/Dockerfile-7.0-cli
@@ -69,6 +69,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.1
+++ b/php/legacy/Dockerfile-7.1
@@ -73,6 +73,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.1-cli
+++ b/php/legacy/Dockerfile-7.1-cli
@@ -69,6 +69,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.2
+++ b/php/legacy/Dockerfile-7.2
@@ -73,6 +73,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.2-cli
+++ b/php/legacy/Dockerfile-7.2-cli
@@ -69,6 +69,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.3
+++ b/php/legacy/Dockerfile-7.3
@@ -73,6 +73,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache

--- a/php/legacy/Dockerfile-7.3-cli
+++ b/php/legacy/Dockerfile-7.3-cli
@@ -69,6 +69,7 @@ RUN set -eux; \
 # Configure Apache & PHP
 ENV PHP_MAX_EXECUTION_TIME 30
 ENV PHP_MEMORY_LIMIT 2G
+ENV PHP_SESSION_SAVE_PATH ""
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
 
 # Configure OPcache


### PR DESCRIPTION
Allow modify the [`session.save_path` INI directive](https://www.php.net/manual/en/session.configuration.php#ini.session.save-path) by ENV variable `PHP_SESSION_SAVE_PATH`.

See more at Readme