### PR TITLE
MySQL: Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Images for local development in [LAMP devstack](https://en.wikipedia.org/wiki/LA
 - with current **PHP** versions: 8.1, 8.0 and 7.4
 - unsupported **PHP** versions also available: 7.3, 7.2, 7.1, 7.0, 5.6, 5.5 and 5.4 (with limited stability,
 unoptimized, unmaintained)
-- current versions of **MariaDB** 10.3, 10.4, 10.5, 10.6, 10.7 and RC pre-release of 10.8
+- current versions of **MariaDB** 10.3, 10.4, 10.5, 10.6, 10.7, 10.8 and RC pre-release of 10.9
 - current version of **Apache** 2.4 (in non-CLI images)
 - current version of **Xdebug** 3.1 (in debug images)
 - extra PHP extensions:
@@ -129,8 +129,9 @@ Available MySQL images:
 - 10.4: `jakubboucek/lamp-devstack-mysql:10.4`
 - 10.5: `jakubboucek/lamp-devstack-mysql:10.5`
 - 10.6: `jakubboucek/lamp-devstack-mysql:10.6`
-- 10.7: `jakubboucek/lamp-devstack-mysql:latest`
-- 10.8: `jakubboucek/lamp-devstack-mysql:10.8-rc`
+- 10.7: `jakubboucek/lamp-devstack-mysql:10.7`
+- 10.8: `jakubboucek/lamp-devstack-mysql:latest`
+- 10.8: `jakubboucek/lamp-devstack-mysql:10.9-rc`
 
 LTS (long-term support) MySQL images (currently 10.6):
 

--- a/build-mariadb.sh
+++ b/build-mariadb.sh
@@ -10,7 +10,7 @@ NO_TEST=${NO_TEST:-0}
 NO_PUSH=${NO_PUSH:-0}
 
 ### MariaDB - 10.3
-MARIADB_RELEASE=34
+MARIADB_RELEASE=35
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.3.${MARIADB_RELEASE}
     docker tag mariadb:10.3.${MARIADB_RELEASE} mariadb:10.3
@@ -33,7 +33,7 @@ fi
 
 
 ### MariaDB - 10.4
-MARIADB_RELEASE=24
+MARIADB_RELEASE=25
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.4.${MARIADB_RELEASE}
     docker tag mariadb:10.4.${MARIADB_RELEASE} mariadb:10.4
@@ -56,7 +56,7 @@ fi
 
 
 ### MariaDB - 10.5
-MARIADB_RELEASE=15
+MARIADB_RELEASE=16
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.5.${MARIADB_RELEASE}
     docker tag mariadb:10.5.${MARIADB_RELEASE} mariadb:10.5
@@ -79,7 +79,7 @@ fi
 
 
 ### MariaDB - 10.6
-MARIADB_RELEASE=7
+MARIADB_RELEASE=8
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.6.${MARIADB_RELEASE}
     docker tag mariadb:10.6.${MARIADB_RELEASE} mariadb:10.6
@@ -106,7 +106,7 @@ fi
 
 
 ### MariaDB - 10.7
-MARIADB_RELEASE=3
+MARIADB_RELEASE=4
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.7.${MARIADB_RELEASE}
     docker tag mariadb:10.7.${MARIADB_RELEASE} mariadb:10.7
@@ -115,8 +115,6 @@ fi
 
 if [ "${NO_BUILD}" -ne "1" ]; then
     docker build --progress plain -f mysql/Dockerfile-10.7 -t jakubboucek/lamp-devstack-mysql:10.7 mysql/
-    docker tag jakubboucek/lamp-devstack-mysql:10.7 jakubboucek/lamp-devstack-mysql:latest
-    docker tag jakubboucek/lamp-devstack-mysql:10.7 jakubboucek/lamp-devstack-mysql:10
     docker tag jakubboucek/lamp-devstack-mysql:10.7 jakubboucek/lamp-devstack-mysql:10.7.${MARIADB_RELEASE}
 fi
 
@@ -127,13 +125,11 @@ fi
 if [ "${NO_PUSH}" -ne "1" ]; then
     docker push jakubboucek/lamp-devstack-mysql:10.7.${MARIADB_RELEASE}
     docker push jakubboucek/lamp-devstack-mysql:10.7
-    docker push jakubboucek/lamp-devstack-mysql:10
-    docker push jakubboucek/lamp-devstack-mysql:latest
 fi
 
 
 ### MariaDB - 10.8
-MARIADB_RELEASE=2
+MARIADB_RELEASE=3
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.8.${MARIADB_RELEASE}
     docker tag mariadb:10.8.${MARIADB_RELEASE} mariadb:10.8
@@ -141,15 +137,42 @@ if [ "${NO_PULL}" -ne "1" ]; then
 fi
 
 if [ "${NO_BUILD}" -ne "1" ]; then
-    docker build --progress plain -f mysql/Dockerfile-10.8 -t jakubboucek/lamp-devstack-mysql:10.8-rc mysql/
-    docker tag jakubboucek/lamp-devstack-mysql:10.8-rc jakubboucek/lamp-devstack-mysql:10.8.${MARIADB_RELEASE}-rc
+    docker build --progress plain -f mysql/Dockerfile-10.8 -t jakubboucek/lamp-devstack-mysql:10.8 mysql/
+    docker tag jakubboucek/lamp-devstack-mysql:10.8 jakubboucek/lamp-devstack-mysql:latest
+    docker tag jakubboucek/lamp-devstack-mysql:10.8 jakubboucek/lamp-devstack-mysql:10
+    docker tag jakubboucek/lamp-devstack-mysql:10.8 jakubboucek/lamp-devstack-mysql:10.8.${MARIADB_RELEASE}
 fi
 
 if [ "${NO_TEST}" -ne "1" ]; then
-    docker run --rm jakubboucek/lamp-devstack-mysql:10.8-rc mysql --version
+    docker run --rm jakubboucek/lamp-devstack-mysql:10.8 mysql --version
 fi
 
 if [ "${NO_PUSH}" -ne "1" ]; then
-    docker push jakubboucek/lamp-devstack-mysql:10.8.${MARIADB_RELEASE}-rc
-    docker push jakubboucek/lamp-devstack-mysql:10.8-rc
+    docker push jakubboucek/lamp-devstack-mysql:10.8.${MARIADB_RELEASE}
+    docker push jakubboucek/lamp-devstack-mysql:10.8
+    docker push jakubboucek/lamp-devstack-mysql:10
+    docker push jakubboucek/lamp-devstack-mysql:latest
+fi
+
+
+### MariaDB - 10.9
+MARIADB_RELEASE=1
+if [ "${NO_PULL}" -ne "1" ]; then
+    docker pull mariadb:10.9.${MARIADB_RELEASE}-rc
+    docker tag mariadb:10.9.${MARIADB_RELEASE}-rc mariadb:10.9-rc
+    docker run --rm mariadb:10.9-rc mysql --version
+fi
+
+if [ "${NO_BUILD}" -ne "1" ]; then
+    docker build --progress plain -f mysql/Dockerfile-10.9 -t jakubboucek/lamp-devstack-mysql:10.9-rc mysql/
+    docker tag jakubboucek/lamp-devstack-mysql:10.9-rc jakubboucek/lamp-devstack-mysql:10.9.${MARIADB_RELEASE}-rc
+fi
+
+if [ "${NO_TEST}" -ne "1" ]; then
+    docker run --rm jakubboucek/lamp-devstack-mysql:10.9-rc mysql --version
+fi
+
+if [ "${NO_PUSH}" -ne "1" ]; then
+    docker push jakubboucek/lamp-devstack-mysql:10.9.${MARIADB_RELEASE}-rc
+    docker push jakubboucek/lamp-devstack-mysql:10.9
 fi

--- a/check-pulls.sh
+++ b/check-pulls.sh
@@ -15,3 +15,5 @@ docker pull mariadb:10.4
 docker pull mariadb:10.5
 docker pull mariadb:10.6
 docker pull mariadb:10.7
+docker pull mariadb:10.8
+docker pull mariadb:10.9-rc

--- a/mysql/Dockerfile-10.9
+++ b/mysql/Dockerfile-10.9
@@ -1,7 +1,7 @@
-FROM mariadb:10.8
+FROM mariadb:10.9-rc
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
-LABEL org.label-schema.name="MariaDB 10.8"
+LABEL org.label-schema.name="MariaDB 10.9 (Release Candidate)"
 LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devstack"
 
 # Workdir during installation


### PR DESCRIPTION
Update MySQL images:

- `10.3.34` → `10.3.35`
- `10.4.24` → `10.4.25`
- `10.5.15` → `10.5.16`
- `10.6.7` → `10.6.8`
- `10.7.3` → `10.7.4`
- `10.8.2-rc` → `10.8.3` (now stable and default for tag `10`)
- `10.9.1-rc` (new minor version, now at RC)
