### PR TITLE
PHP: Fix ENV vars for error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ image content, using environment variables. It can be defined in `docker run` co
 
 Configurable directives:
 
-- `PHP_ERROR_REPORTING` - change the [`error_reporting` directive](https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting) (default value: *empty*)
+- `PHP_ERROR_REPORTING` - change the [`error_reporting` directive](https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting) (default value: `32767`, means `E_ALL`)
 - `PHP_DISPLAY_ERRORS` - change the [`display_errors` directive](https://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors) (default value: `1`)
 - `PHP_DISPLAY_STARTUP_ERRORS` - change the [`display_startup_errors` directive](https://www.php.net/manual/en/errorfunc.configuration.php#ini.display-startup-errors) (default value: `1`, on PHP 7: `0`)
 - `PHP_ERROR_LOG` – change the [`error_log` directive](https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-log) (default value: *empty*)

--- a/php/Dockerfile-7.4
+++ b/php/Dockerfile-7.4
@@ -74,7 +74,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/Dockerfile-7.4-cli
+++ b/php/Dockerfile-7.4-cli
@@ -70,7 +70,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/Dockerfile-8.0
+++ b/php/Dockerfile-8.0
@@ -74,7 +74,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 32767 # E_ALL
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 1
 ENV PHP_ERROR_LOG ""

--- a/php/Dockerfile-8.0-cli
+++ b/php/Dockerfile-8.0-cli
@@ -70,7 +70,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 32767 # E_ALL
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 1
 ENV PHP_ERROR_LOG ""

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -75,7 +75,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 32767 # E_ALL
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 1
 ENV PHP_ERROR_LOG ""

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -71,7 +71,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 32767 # E_ALL
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 1
 ENV PHP_ERROR_LOG ""

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -75,7 +75,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 32767 # E_ALL
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 1
 ENV PHP_ERROR_LOG ""

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -71,7 +71,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 32767 # E_ALL
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 1
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-5.4
+++ b/php/legacy/Dockerfile-5.4
@@ -75,7 +75,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-5.4-cli
+++ b/php/legacy/Dockerfile-5.4-cli
@@ -71,7 +71,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-5.5
+++ b/php/legacy/Dockerfile-5.5
@@ -74,7 +74,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-5.5-cli
+++ b/php/legacy/Dockerfile-5.5-cli
@@ -70,7 +70,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-5.6
+++ b/php/legacy/Dockerfile-5.6
@@ -74,7 +74,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-5.6-cli
+++ b/php/legacy/Dockerfile-5.6-cli
@@ -70,7 +70,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.0
+++ b/php/legacy/Dockerfile-7.0
@@ -73,7 +73,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.0-cli
+++ b/php/legacy/Dockerfile-7.0-cli
@@ -69,7 +69,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.1
+++ b/php/legacy/Dockerfile-7.1
@@ -73,7 +73,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.1-cli
+++ b/php/legacy/Dockerfile-7.1-cli
@@ -69,7 +69,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.2
+++ b/php/legacy/Dockerfile-7.2
@@ -73,7 +73,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.2-cli
+++ b/php/legacy/Dockerfile-7.2-cli
@@ -69,7 +69,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.3
+++ b/php/legacy/Dockerfile-7.3
@@ -73,7 +73,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""

--- a/php/legacy/Dockerfile-7.3-cli
+++ b/php/legacy/Dockerfile-7.3-cli
@@ -69,7 +69,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
 
 # Configure Apache & PHP
-ENV PHP_ERROR_REPORTING ""
+ENV PHP_ERROR_REPORTING 22519 # E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 ENV PHP_DISPLAY_ERRORS 1
 ENV PHP_DISPLAY_STARTUP_ERRORS 0
 ENV PHP_ERROR_LOG ""


### PR DESCRIPTION
This PR fixes bug from #26.

The `error_reporting` directive is corrupted when empty string value set to it. PHP default value it empty too, but it's some magically different empty value.

PR explicitly sets default value, same as is default for PHP without configuration.