### PR TITLE
Fix PHP v5.4 Document Root configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ use `-legacy` tag suffix:
 - `jakubboucek/lamp-devstack-php:7.0-legacy`
 - `jakubboucek/lamp-devstack-php:5.6-legacy`
 - `jakubboucek/lamp-devstack-php:5.5-legacy`
-- `jakubboucek/lamp-devstack-php:5.4-legacy`
+- `jakubboucek/lamp-devstack-php:5.4-legacy-fixed`
+
+> Note: Version 5.4 is using `-fixed` suffix because is unable to rebuild them from scratch. 
 
 All PHP images have alternative variants with XDebug extension preinstalled, use `-debug` tag suffix, example:
 - `jakubboucek/lamp-devstack-php:debug`

--- a/php/legacy/Dockerfile-5.4-debug
+++ b/php/legacy/Dockerfile-5.4-debug
@@ -1,4 +1,4 @@
-FROM jakubboucek/lamp-devstack-php:5.4-legacy
+FROM jakubboucek/lamp-devstack-php:5.4-legacy-fixed
 
 LABEL org.label-schema.name="PHP 5.4 (Apache module + Xdebug)"
 

--- a/php/legacy/Dockerfile-5.4-fixed
+++ b/php/legacy/Dockerfile-5.4-fixed
@@ -1,0 +1,11 @@
+FROM jakubboucek/lamp-devstack-php:5.4-legacy
+
+# Fix add missing ENV variable
+ENV APACHE_LOG_DIR /var/log/apache2
+
+# Enable VirtualHost to apply right DocumentRoot & fix invalid log files
+RUN set -eux; \
+    ln -sfT /dev/stderr "$APACHE_LOG_DIR/error.log"; \
+    ln -sfT /dev/stdout "$APACHE_LOG_DIR/access.log"; \
+    ln -sfT /dev/stdout "$APACHE_LOG_DIR/other_vhosts_access.log"; \
+    a2ensite 000-default;

--- a/php/legacy/build-php-5.4-cli.sh
+++ b/php/legacy/build-php-5.4-cli.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     # Origin image uses outdated schema1 manifest format - use DOCKER_BUILDKIT=0
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.4-cli -t jakubboucek/lamp-devstack-php:5.4-legacy-cli ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.4-cli -t jakubboucek/lamp-devstack-php:5.4-legacy-cli ../
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then

--- a/php/legacy/build-php-5.4.sh
+++ b/php/legacy/build-php-5.4.sh
@@ -13,19 +13,22 @@ fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     # Origin image uses outdated schema1 manifest format - use DOCKER_BUILDKIT=0
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.4 -t jakubboucek/lamp-devstack-php:5.4-legacy ../
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.4-debug -t jakubboucek/lamp-devstack-php:5.4-legacy-debug ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.4 -t jakubboucek/lamp-devstack-php:5.4-legacy ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.4-fixed -t jakubboucek/lamp-devstack-php:5.4-legacy-fixed ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.4-debug -t jakubboucek/lamp-devstack-php:5.4-legacy-debug ../
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then
     docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy php --version
+    docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy-fixed php --version
     docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy-debug php --version
-    docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy-fixed php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
     docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy-debug php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
-    docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy php -r "var_export(gd_info()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:5.4-legacy-fixed php -r "var_export(gd_info()) . PHP_EOL;"
 fi
 
 if [ "${NO_PUSH:-0}" -ne "1" ]; then
     docker push jakubboucek/lamp-devstack-php:5.4-legacy-debug
+    docker push jakubboucek/lamp-devstack-php:5.4-legacy-fixed
     docker push jakubboucek/lamp-devstack-php:5.4-legacy
 fi

--- a/php/legacy/build-php-5.5-cli.sh
+++ b/php/legacy/build-php-5.5-cli.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     # Origin image uses outdated schema1 manifest format - use DOCKER_BUILDKIT=0
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.5-cli -t jakubboucek/lamp-devstack-php:5.5-legacy-cli ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.5-cli -t jakubboucek/lamp-devstack-php:5.5-legacy-cli ../
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then

--- a/php/legacy/build-php-5.5.sh
+++ b/php/legacy/build-php-5.5.sh
@@ -13,8 +13,8 @@ fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     # Origin image uses outdated schema1 manifest format - use DOCKER_BUILDKIT=0
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.5 -t jakubboucek/lamp-devstack-php:5.5-legacy ../
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.5-debug -t jakubboucek/lamp-devstack-php:5.5-legacy-debug ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.5 -t jakubboucek/lamp-devstack-php:5.5-legacy ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.5-debug -t jakubboucek/lamp-devstack-php:5.5-legacy-debug ../
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then

--- a/php/legacy/build-php-5.6-cli.sh
+++ b/php/legacy/build-php-5.6-cli.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     # Origin image uses outdated schema1 manifest format - use DOCKER_BUILDKIT=0
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.6-cli -t jakubboucek/lamp-devstack-php:5.6-legacy-cli ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.6-cli -t jakubboucek/lamp-devstack-php:5.6-legacy-cli ../
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then

--- a/php/legacy/build-php-5.6.sh
+++ b/php/legacy/build-php-5.6.sh
@@ -13,8 +13,8 @@ fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     # Origin image uses outdated schema1 manifest format - use DOCKER_BUILDKIT=0
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.6 -t jakubboucek/lamp-devstack-php:5.6-legacy ../
-    DOCKER_BUILDKIT=0 docker build --progress plain -f ./Dockerfile-5.6-debug -t jakubboucek/lamp-devstack-php:5.6-legacy-debug ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.6 -t jakubboucek/lamp-devstack-php:5.6-legacy ../
+    DOCKER_BUILDKIT=0 docker build -f ./Dockerfile-5.6-debug -t jakubboucek/lamp-devstack-php:5.6-legacy-debug ../
     docker tag jakubboucek/lamp-devstack-php:5.6-legacy jakubboucek/lamp-devstack-php:5-legacy
     docker tag jakubboucek/lamp-devstack-php:5.6-legacy-debug jakubboucek/lamp-devstack-php:5-legacy-debug
 fi


### PR DESCRIPTION
Image for PHP 5.4 has bug to use defined DocumentRoot. This PR is fixes it.

Currently is unable to rebuild thile image from scratch because Debian repositories is no more supports Jessie version. Patch is built as new image with the `-fixed` tag suffix. 