### PR TITLE
Mariadb update

### DIFF
--- a/build-mariadb.sh
+++ b/build-mariadb.sh
@@ -10,7 +10,7 @@ NO_TEST=${NO_TEST:-0}
 NO_PUSH=${NO_PUSH:-0}
 
 ### MariaDB - 10.4
-MARIADB_RELEASE=30
+MARIADB_RELEASE=31
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.4.${MARIADB_RELEASE}
     docker tag mariadb:10.4.${MARIADB_RELEASE} mariadb:10.4
@@ -33,7 +33,7 @@ fi
 
 
 ### MariaDB - 10.5
-MARIADB_RELEASE=21
+MARIADB_RELEASE=22
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.5.${MARIADB_RELEASE}
     docker tag mariadb:10.5.${MARIADB_RELEASE} mariadb:10.5
@@ -56,7 +56,7 @@ fi
 
 
 ### MariaDB - 10.6
-MARIADB_RELEASE=14
+MARIADB_RELEASE=15
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.6.${MARIADB_RELEASE}
     docker tag mariadb:10.6.${MARIADB_RELEASE} mariadb:10.6
@@ -79,7 +79,7 @@ fi
 
 
 ### MariaDB - 10.9
-MARIADB_RELEASE=7
+MARIADB_RELEASE=8
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.9.${MARIADB_RELEASE}
     docker tag mariadb:10.9.${MARIADB_RELEASE} mariadb:10.9
@@ -102,7 +102,7 @@ fi
 
 
 ### MariaDB - 10.10
-MARIADB_RELEASE=5
+MARIADB_RELEASE=6
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.10.${MARIADB_RELEASE}
     docker tag mariadb:10.10.${MARIADB_RELEASE} mariadb:10.10
@@ -124,7 +124,7 @@ if [ "${NO_PUSH}" -ne "1" ]; then
 fi
 
 ### MariaDB - 10.11
-MARIADB_RELEASE=4
+MARIADB_RELEASE=5
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.11.${MARIADB_RELEASE}
     docker tag mariadb:10.11.${MARIADB_RELEASE} mariadb:10.11
@@ -152,7 +152,7 @@ if [ "${NO_PUSH}" -ne "1" ]; then
 fi
 
 ### MariaDB - 11.0
-MARIADB_RELEASE=2
+MARIADB_RELEASE=3
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:11.0.${MARIADB_RELEASE}
     docker tag mariadb:11.0.${MARIADB_RELEASE} mariadb:11.0

--- a/check-pulls.sh
+++ b/check-pulls.sh
@@ -16,8 +16,6 @@ docker pull mariadb:10.3
 docker pull mariadb:10.4
 docker pull mariadb:10.5
 docker pull mariadb:10.6
-docker pull mariadb:10.7
-docker pull mariadb:10.8
 docker pull mariadb:10.9
 docker pull mariadb:10.10
 docker pull mariadb:10.11


### PR DESCRIPTION
Update MariaDB to versions:

- 10.4.31
- 10.5.22
- 10.6.15
- 10.9.8
- 10.10.6
- 10.11.5
- 11.0.3

And remove checking of dropped versions 10.7 and 10.8.