### PR TITLE
docker-compose.yml: 'version' is obsolete

### DIFF
--- a/docker-compose-debug.yml
+++ b/docker-compose-debug.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     web:
         image: jakubboucek/lamp-devstack-php:debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     web:
         image: jakubboucek/lamp-devstack-php


### PR DESCRIPTION
The `version` field is no more used, now Docker is throwing a Warning.

PR is removing this field.

- Docker doc: https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional
- Warning issue: mailcow/mailcow-dockerized#5797