### PR TITLE
MariaDB update

### DIFF
--- a/build-mariadb.sh
+++ b/build-mariadb.sh
@@ -10,7 +10,7 @@ NO_TEST=${NO_TEST:-0}
 NO_PUSH=${NO_PUSH:-0}
 
 ### MariaDB - 10.4
-MARIADB_RELEASE=33
+MARIADB_RELEASE=34
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.4.${MARIADB_RELEASE}
     docker tag mariadb:10.4.${MARIADB_RELEASE} mariadb:10.4
@@ -33,7 +33,7 @@ fi
 
 
 ### MariaDB - 10.5
-MARIADB_RELEASE=24
+MARIADB_RELEASE=25
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.5.${MARIADB_RELEASE}
     docker tag mariadb:10.5.${MARIADB_RELEASE} mariadb:10.5
@@ -56,7 +56,7 @@ fi
 
 
 ### MariaDB - 10.6
-MARIADB_RELEASE=17
+MARIADB_RELEASE=18
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.6.${MARIADB_RELEASE}
     docker tag mariadb:10.6.${MARIADB_RELEASE} mariadb:10.6
@@ -78,7 +78,7 @@ if [ "${NO_PUSH}" -ne "1" ]; then
 fi
 
 ### MariaDB - 10.11
-MARIADB_RELEASE=7
+MARIADB_RELEASE=8
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.11.${MARIADB_RELEASE}
     docker tag mariadb:10.11.${MARIADB_RELEASE} mariadb:10.11
@@ -106,7 +106,7 @@ if [ "${NO_PUSH}" -ne "1" ]; then
 fi
 
 ### MariaDB - 11.0
-MARIADB_RELEASE=5
+MARIADB_RELEASE=6
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:11.0.${MARIADB_RELEASE}
     docker tag mariadb:11.0.${MARIADB_RELEASE} mariadb:11.0
@@ -128,7 +128,7 @@ if [ "${NO_PUSH}" -ne "1" ]; then
 fi
 
 ### MariaDB - 11.1
-MARIADB_RELEASE=4
+MARIADB_RELEASE=5
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:11.1.${MARIADB_RELEASE}
     docker tag mariadb:11.1.${MARIADB_RELEASE} mariadb:11.1
@@ -151,7 +151,7 @@ fi
 
 
 ### MariaDB - 11.2
-MARIADB_RELEASE=3
+MARIADB_RELEASE=4
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:11.2.${MARIADB_RELEASE}
     docker tag mariadb:11.2.${MARIADB_RELEASE} mariadb:11.2

--- a/check-pulls.sh
+++ b/check-pulls.sh
@@ -10,7 +10,6 @@ docker pull php:8.2-apache-bookworm
 docker pull php:8.3-cli-bookworm
 docker pull php:8.3-apache-bookworm
 
-docker pull mariadb:10.3
 docker pull mariadb:10.4
 docker pull mariadb:10.5
 docker pull mariadb:10.6


### PR DESCRIPTION
Updates:

- from `10.4.33` to `10.4.34`
- from `10.5.24` to `10.5.25`
- from `10.6.17` to `10.6.18`
- from `10.11.7` to `10.11.8`
- from `11.0.5` to `11.0.6`
- from `11.1.4` to `11.1.5`
- from `11.2.3` to `11.2.4`