### PR TITLE
PHP: Add Opcache JIT options configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Configurable directives:
 - `PHP_OPCACHE_BLACKLIST_FILENAME` – change the [`opcache.blacklist_filename` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.blacklist-filename) (default value: *empty*)
 - `PHP_OPCACHE_ENABLE` – change the [`opcache.enable` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.enable) (default value: `1`)
 - `PHP_OPCACHE_ENABLE_CLI` – change the [`opcache.enable_cli` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.enable-cli) (default value: `0`)
+- `PHP_OPCACHE_JIT` – change the [`opcache.jit` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit) (default value: `tracing`, on PHP 8.4 [changed](https://php.watch/versions/8.4/opcache-jit-ini-default-changes): `disable`)
+- `PHP_OPCACHE_JIT_BUFFER_SIZE` – change the [`opcache.jit_buffer_size` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit-buffer-size) (default value: `0`, on PHP 8.4 [changed](https://php.watch/versions/8.4/opcache-jit-ini-default-changes): `64M`)
 - `PHP_OPCACHE_MEMORY_CONSUPTION` – change the [`opcache.memory_consumption` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.memory-consumption) (default value: `128`)
 - `PHP_OPCACHE_PRELOAD` – change the [`opcache.preload` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload) (default value: *empty*)
 - `PHP_OPCACHE_PRELOAD_USER` – change the [`opcache.preload_user` directive](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload-user) (default value: *empty*)

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -90,6 +90,8 @@ COPY core.ini /usr/local/etc/php/conf.d/core.ini
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=tracing
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=0
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
@@ -97,6 +99,7 @@ ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 RUN set -eux; \

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -86,6 +86,8 @@ COPY core.ini /usr/local/etc/php/conf.d/core.ini
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=tracing
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=0
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
@@ -93,6 +95,7 @@ ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 RUN set -eux; \

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -91,6 +91,8 @@ COPY core.ini /usr/local/etc/php/conf.d/core.ini
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=tracing
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=0
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
@@ -98,6 +100,7 @@ ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 RUN set -eux; \

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -87,6 +87,8 @@ COPY core.ini /usr/local/etc/php/conf.d/core.ini
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=tracing
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=0
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
@@ -94,6 +96,7 @@ ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 RUN set -eux; \

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -91,6 +91,8 @@ COPY core.ini /usr/local/etc/php/conf.d/core.ini
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=tracing
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=0
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
@@ -98,6 +100,7 @@ ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 RUN set -eux; \

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -87,6 +87,8 @@ COPY core.ini /usr/local/etc/php/conf.d/core.ini
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=tracing
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=0
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
@@ -94,6 +96,7 @@ ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 RUN set -eux; \

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -81,18 +81,21 @@ ENV PHP_MEMORY_LIMIT=2G
 ENV PHP_SESSION_SAVE_PATH=""
 ENV TZ=UTC
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
-COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
 
 # Configure OPcache
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=disable
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=64M
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
 ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 # RUN set -eux; \

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -77,18 +77,21 @@ ENV PHP_MEMORY_LIMIT=2G
 ENV PHP_SESSION_SAVE_PATH=""
 ENV TZ=UTC
 COPY core.ini /usr/local/etc/php/conf.d/core.ini
-COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
 
 # Configure OPcache
 ENV PHP_OPCACHE_BLACKLIST_FILENAME=""
 ENV PHP_OPCACHE_ENABLE=1
 ENV PHP_OPCACHE_ENABLE_CLI=0
+ENV PHP_OPCACHE_JIT=disable
+ENV PHP_OPCACHE_JIT_BUFFER_SIZE=64M
 ENV PHP_OPCACHE_MEMORY_CONSUPTION=128
 ENV PHP_OPCACHE_PRELOAD=""
 ENV PHP_OPCACHE_PRELOAD_USER=""
 ENV PHP_OPCACHE_REVALIDATE_FREQ=2
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
 COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+COPY opcache-7.4.ini /usr/local/etc/php/conf.d/opcache-7.4.ini
+COPY opcache-jit.ini /usr/local/etc/php/conf.d/opcache-jit.ini
 
 # Install Mecached extension
 # RUN set -eux; \

--- a/php/opcache-jit.ini
+++ b/php/opcache-jit.ini
@@ -1,0 +1,2 @@
+opcache.jit = ${PHP_OPCACHE_JIT}
+opcache.jit_buffer_size = ${PHP_OPCACHE_BUFFER_SIZE}

--- a/php/opcache-jit.ini
+++ b/php/opcache-jit.ini
@@ -1,2 +1,2 @@
 opcache.jit = ${PHP_OPCACHE_JIT}
-opcache.jit_buffer_size = ${PHP_OPCACHE_BUFFER_SIZE}
+opcache.jit_buffer_size = ${PHP_OPCACHE_JIT_BUFFER_SIZE}


### PR DESCRIPTION
- Add `PHP_OPCACHE_JIT` and `PHP_OPCACHE_JIT_BUFFER_SIZE` environment variables for customize [`opcache.jit`](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit) and [`opcache.jit_buffer_size`](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit-buffer-size) directives.

Read more at README file.