### PR TITLE
PHP 8.4 is now stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Images for local development in [LAMP devstack](https://en.wikipedia.org/wiki/LA
 
 ## Main features
 - architecture: `linux/amd64`
-- current **PHP** versions: 8.3, 8.2 and 8.1 and RC pre-release of 8.4
+- current **PHP** versions: 8.4, 8.3, 8.2 and 8.1
 - unsupported **PHP** versions also available: 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5 and 5.4 (with limited stability,
 unoptimized, unmaintained)
 - current versions of **MariaDB** 11.5, 11.4, 11.2, 10.11, 10.6, 10.5, and RC pre-release of 11.6
@@ -94,8 +94,8 @@ my_project/                 <-- project's root
 Images are tagged by the cascaded SemVer:
 - `jakubboucek/lamp-devstack-php:latest` – means `latest` available stable PHP image,
 - `jakubboucek/lamp-devstack-php:8` – represents the highest PHP image of `8` version, but lower than `9.0.0`,
-- `jakubboucek/lamp-devstack-php:8.3` – represents the highest PHP image of `8.3` version, but lower than `8.4.0`,
-- `jakubboucek/lamp-devstack-php:8.3.0` – represents most specific PHP image, directly version `8.3.0`.
+- `jakubboucek/lamp-devstack-php:8.4` – represents the highest PHP image of `8.4` version, but lower than `8.5.0`,
+- `jakubboucek/lamp-devstack-php:8.4.0` – represents most specific PHP image, directly version `8.4.0`.
 
 **Legacy PHP** images are tagged using different strategy, only latest revision for each minor version is available,
 use `-legacy` tag suffix:
@@ -115,27 +115,18 @@ use `-legacy` tag suffix:
 All PHP images have alternative variants with XDebug extension preinstalled, use `-debug` tag suffix, example:
 - `jakubboucek/lamp-devstack-php:debug`
 - `jakubboucek/lamp-devstack-php:8-debug`
-- `jakubboucek/lamp-devstack-php:8.3-debug`
-- `jakubboucek/lamp-devstack-php:8.3.0-debug`
-- `jakubboucek/lamp-devstack-php:8.4.0-rc-cli`
+- `jakubboucek/lamp-devstack-php:8.4-debug`
+- `jakubboucek/lamp-devstack-php:8.4.0-debug`
 - `jakubboucek/lamp-devstack-php:7.4-legacy-debug`
 
->  Note: (Pre-release of PHP 8.4 contains unstable version of Xdebug)
+>  Note: (PHP 8.4 temporary contains beta version of Xdebug)
 
 All PHP images also have alternative CLI variants, use `-cli` tag suffix, example:
 - `jakubboucek/lamp-devstack-php:cli`
 - `jakubboucek/lamp-devstack-php:8-cli`
-- `jakubboucek/lamp-devstack-php:8.3-cli`
-- `jakubboucek/lamp-devstack-php:8.3.0-cli`
+- `jakubboucek/lamp-devstack-php:8.4-cli`
+- `jakubboucek/lamp-devstack-php:8.4.0-cli`
 - `jakubboucek/lamp-devstack-php:7.4-legacy-cli`
-
-The RC pre-release of PHP 8.4 images have the `-rc` suffix, example:
-- `jakubboucek/lamp-devstack-php:8.4-rc`
-- `jakubboucek/lamp-devstack-php:8.4-0-rc`
-- `jakubboucek/lamp-devstack-php:8.4-0-rc-RC2`
-- `jakubboucek/lamp-devstack-php:8.4-rc-cli`
-- `jakubboucek/lamp-devstack-php:8.4-0-rc-cli`
-- `jakubboucek/lamp-devstack-php:8.4-0-rc-RC2-cli`
 
 ### Using MySQL
 MySQL server starts at the same time as the web server.

--- a/build-notes.md
+++ b/build-notes.md
@@ -7,7 +7,7 @@ This note is not necessary for USE images, it's for BUILD him.
 Run [`build-php.sh`](build-php.sh) script to build all of PHP versions.
 
 To build only specific PHP version run only the target script on [`php` folder](php), for example:
-[`php/build-php-8.3.sh`](php/build-php-8.3.sh)
+[`php/build-php-8.4.sh`](php/build-php-8.4.sh)
 
 To build older PHP versions run [`php/legacy/build-php-legacy.sh`](php/legacy/build-php-legacy.sh).
 

--- a/check-pulls.sh
+++ b/check-pulls.sh
@@ -9,8 +9,8 @@ docker pull php:8.2-cli-bookworm
 docker pull php:8.2-apache-bookworm
 docker pull php:8.3-cli-bookworm
 docker pull php:8.3-apache-bookworm
-docker pull php:8.4-rc-cli-bookworm
-docker pull php:8.4-rc-apache-bookworm
+docker pull php:8.4-cli-bookworm
+docker pull php:8.4-apache-bookworm
 
 docker pull mariadb:10.5
 docker pull mariadb:10.6

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -1,7 +1,7 @@
-FROM php:8.4-rc-apache-bookworm
+FROM php:8.4-apache-bookworm
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
-LABEL org.label-schema.name="PHP 8.4 (Pre-release, Apache module)"
+LABEL org.label-schema.name="PHP 8.4 (Apache module)"
 LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devstack"
 
 # Workdir during installation

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -1,7 +1,7 @@
-FROM php:8.4-rc-cli-bookworm
+FROM php:8.4-cli-bookworm
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
-LABEL org.label-schema.name="PHP 8.4 (Pre-release, CLI)"
+LABEL org.label-schema.name="PHP 8.4 (CLI)"
 LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devstack"
 
 # Workdir during installation

--- a/php/Dockerfile-8.4-debug
+++ b/php/Dockerfile-8.4-debug
@@ -1,6 +1,6 @@
-FROM jakubboucek/lamp-devstack-php:8.4-rc
+FROM jakubboucek/lamp-devstack-php:8.4
 
-LABEL org.label-schema.name="PHP 8.4 (Pre-release, Apache module + Xdebug)"
+LABEL org.label-schema.name="PHP 8.4 (Apache module + Xdebug)"
 
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/build-php-8.3-cli.sh
+++ b/php/build-php-8.3-cli.sh
@@ -14,8 +14,6 @@ fi
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     docker build --progress plain -f ./Dockerfile-8.3-cli -t jakubboucek/lamp-devstack-php:8.3-cli ./
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.3-cli php -r "echo PHP_RELEASE_VERSION;")
-    docker tag jakubboucek/lamp-devstack-php:8.3-cli jakubboucek/lamp-devstack-php:cli
-    docker tag jakubboucek/lamp-devstack-php:8.3-cli jakubboucek/lamp-devstack-php:8-cli
     docker tag jakubboucek/lamp-devstack-php:8.3-cli jakubboucek/lamp-devstack-php:8.3.${PHP_RELEASE}-cli
 fi
 
@@ -29,6 +27,4 @@ if [ "${NO_PUSH:-0}" -ne "1" ]; then
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.3-cli php -r "echo PHP_RELEASE_VERSION;")
     docker push jakubboucek/lamp-devstack-php:8.3.${PHP_RELEASE}-cli
     docker push jakubboucek/lamp-devstack-php:8.3-cli
-    docker push jakubboucek/lamp-devstack-php:8-cli
-    docker push jakubboucek/lamp-devstack-php:cli
 fi

--- a/php/build-php-8.3.sh
+++ b/php/build-php-8.3.sh
@@ -15,11 +15,7 @@ if [ "${NO_BUILD:-0}" -ne "1" ]; then
     docker build --progress plain -f ./Dockerfile-8.3 -t jakubboucek/lamp-devstack-php:8.3 ./
     docker build --progress plain -f ./Dockerfile-8.3-debug -t jakubboucek/lamp-devstack-php:8.3-debug ./
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.3 php -r "echo PHP_RELEASE_VERSION;")
-    docker tag jakubboucek/lamp-devstack-php:8.3 jakubboucek/lamp-devstack-php:latest
-    docker tag jakubboucek/lamp-devstack-php:8.3 jakubboucek/lamp-devstack-php:8
     docker tag jakubboucek/lamp-devstack-php:8.3 jakubboucek/lamp-devstack-php:8.3.${PHP_RELEASE}
-    docker tag jakubboucek/lamp-devstack-php:8.3-debug jakubboucek/lamp-devstack-php:debug
-    docker tag jakubboucek/lamp-devstack-php:8.3-debug jakubboucek/lamp-devstack-php:8-debug
     docker tag jakubboucek/lamp-devstack-php:8.3-debug jakubboucek/lamp-devstack-php:8.3.${PHP_RELEASE}-debug
 fi
 
@@ -35,10 +31,6 @@ if [ "${NO_PUSH:-0}" -ne "1" ]; then
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.3 php -r "echo PHP_RELEASE_VERSION;")
     docker push jakubboucek/lamp-devstack-php:8.3.${PHP_RELEASE}-debug
     docker push jakubboucek/lamp-devstack-php:8.3-debug
-    docker push jakubboucek/lamp-devstack-php:8-debug
-    docker push jakubboucek/lamp-devstack-php:debug
     docker push jakubboucek/lamp-devstack-php:8.3.${PHP_RELEASE}
     docker push jakubboucek/lamp-devstack-php:8.3
-    docker push jakubboucek/lamp-devstack-php:8
-    docker push jakubboucek/lamp-devstack-php:latest
 fi

--- a/php/build-php-8.4-cli.sh
+++ b/php/build-php-8.4-cli.sh
@@ -5,34 +5,30 @@ set -eux;
 
 cd "$(dirname $0)";
 
-### PHP 8.4-rc
+### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.4-rc-cli-bookworm
-    docker run --rm php:8.4-rc-cli-bookworm php --version
+    docker pull php:8.4-cli-bookworm
+    docker run --rm php:8.4-cli-bookworm php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
-    docker build --progress plain -f ./Dockerfile-8.4-cli -t jakubboucek/lamp-devstack-php:8.4-rc-cli ./
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-cli php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-cli php -r "echo PHP_EXTRA_VERSION;")
-#    docker tag jakubboucek/lamp-devstack-php:8.4-rc-cli jakubboucek/lamp-devstack-php:cli
-#    docker tag jakubboucek/lamp-devstack-php:8.4-rc-cli jakubboucek/lamp-devstack-php:8-cli
-    docker tag jakubboucek/lamp-devstack-php:8.4-rc-cli jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-cli
-    docker tag jakubboucek/lamp-devstack-php:8.4-rc-cli jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}-cli
+    docker build --progress plain -f ./Dockerfile-8.4-cli -t jakubboucek/lamp-devstack-php:8.4-cli ./
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-cli php -r "echo PHP_RELEASE_VERSION;")
+    docker tag jakubboucek/lamp-devstack-php:8.4-cli jakubboucek/lamp-devstack-php:cli
+    docker tag jakubboucek/lamp-devstack-php:8.4-cli jakubboucek/lamp-devstack-php:8-cli
+    docker tag jakubboucek/lamp-devstack-php:8.4-cli jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-cli
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-cli php --version
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-cli php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-cli php -r "var_export(gd_info()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.4-cli php --version
+    docker run --rm jakubboucek/lamp-devstack-php:8.4-cli php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.4-cli php -r "var_export(gd_info()) . PHP_EOL;"
 fi
 
 if [ "${NO_PUSH:-0}" -ne "1" ]; then
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-cli php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-cli php -r "echo PHP_EXTRA_VERSION;")
-    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}-cli
-    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-cli
-    docker push jakubboucek/lamp-devstack-php:8.4-rc-cli
-#    docker push jakubboucek/lamp-devstack-php:8-cli
-#    docker push jakubboucek/lamp-devstack-php:cli
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-cli php -r "echo PHP_RELEASE_VERSION;")
+    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-cli
+    docker push jakubboucek/lamp-devstack-php:8.4-cli
+    docker push jakubboucek/lamp-devstack-php:8-cli
+    docker push jakubboucek/lamp-devstack-php:cli
 fi

--- a/php/build-php-8.4.sh
+++ b/php/build-php-8.4.sh
@@ -5,45 +5,40 @@ set -eux;
 
 cd "$(dirname $0)";
 
-### PHP 8.4-rc
+### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.4-rc-apache-bookworm
-    docker run --rm php:8.4-rc-apache-bookworm php --version
+    docker pull php:8.4-apache-bookworm
+    docker run --rm php:8.4-apache-bookworm php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
-    docker build --progress plain -f ./Dockerfile-8.4 -t jakubboucek/lamp-devstack-php:8.4-rc ./
-    docker build --progress plain -f ./Dockerfile-8.4-debug -t jakubboucek/lamp-devstack-php:8.4-rc-debug ./
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc php -r "echo PHP_EXTRA_VERSION;")
-#    docker tag jakubboucek/lamp-devstack-php:8.4-rc jakubboucek/lamp-devstack-php:8
-#    docker tag jakubboucek/lamp-devstack-php:8.4-rc jakubboucek/lamp-devstack-php:latest
-    docker tag jakubboucek/lamp-devstack-php:8.4-rc jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc
-    docker tag jakubboucek/lamp-devstack-php:8.4-rc jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}
-#    docker tag jakubboucek/lamp-devstack-php:8.4-rc-debug jakubboucek/lamp-devstack-php:debug
-#    docker tag jakubboucek/lamp-devstack-php:8.4-rc-debug jakubboucek/lamp-devstack-php:8-debug
-    docker tag jakubboucek/lamp-devstack-php:8.4-rc-debug jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-debug
-    docker tag jakubboucek/lamp-devstack-php:8.4-rc-debug jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-debug-${PHP_RELEASE_EXTRA}
+    docker build --progress plain -f ./Dockerfile-8.4 -t jakubboucek/lamp-devstack-php:8.4 ./
+    docker build --progress plain -f ./Dockerfile-8.4-debug -t jakubboucek/lamp-devstack-php:8.4-debug ./
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4 php -r "echo PHP_RELEASE_VERSION;")
+    docker tag jakubboucek/lamp-devstack-php:8.4 jakubboucek/lamp-devstack-php:8
+    docker tag jakubboucek/lamp-devstack-php:8.4 jakubboucek/lamp-devstack-php:latest
+    docker tag jakubboucek/lamp-devstack-php:8.4 jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}
+    docker tag jakubboucek/lamp-devstack-php:8.4-debug jakubboucek/lamp-devstack-php:debug
+    docker tag jakubboucek/lamp-devstack-php:8.4-debug jakubboucek/lamp-devstack-php:8-debug
+    docker tag jakubboucek/lamp-devstack-php:8.4-debug jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-debug
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc php --version
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-debug php --version
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc-debug php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
-    docker run --rm jakubboucek/lamp-devstack-php:8.4-rc php -r "var_export(gd_info()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.4 php --version
+    docker run --rm jakubboucek/lamp-devstack-php:8.4-debug php --version
+    docker run --rm jakubboucek/lamp-devstack-php:8.4 php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.4-debug php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.4 php -r "var_export(gd_info()) . PHP_EOL;"
 fi
 
 if [ "${NO_PUSH:-0}" -ne "1" ]; then
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-rc php -r "echo PHP_EXTRA_VERSION;")
-    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-debug
-    docker push jakubboucek/lamp-devstack-php:8.4-rc-debug
-#    docker push jakubboucek/lamp-devstack-php:8-debug
-#    docker push jakubboucek/lamp-devstack-php:debug
-    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}
-    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-rc
-    docker push jakubboucek/lamp-devstack-php:8.4-rc
-#    docker push jakubboucek/lamp-devstack-php:8
-#    docker push jakubboucek/lamp-devstack-php:latest
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4 php -r "echo PHP_RELEASE_VERSION;")
+    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-debug
+    docker push jakubboucek/lamp-devstack-php:8.4-debug
+    docker push jakubboucek/lamp-devstack-php:8-debug
+    docker push jakubboucek/lamp-devstack-php:debug
+    docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}
+    docker push jakubboucek/lamp-devstack-php:8.4
+    docker push jakubboucek/lamp-devstack-php:8
+    docker push jakubboucek/lamp-devstack-php:latest
 fi


### PR DESCRIPTION
- [Readme: PHP is now default 8.4](https://github.com/jakubboucek/docker-lamp-devstack/commit/7fde5424b0ce37eea1b94ffd598345ecc0d6a1d6)
- [PHP: PHP 8.4 is now stable](https://github.com/jakubboucek/docker-lamp-devstack/commit/855056d19c30a63cf8a0203ed3afd74ad766f20d)
   - Remove `-rc` suffix from PHP 8.4 versions
   - Set PHP 8.4 as default for `:latest` tag (and similar like `:debug`, `:cli`, `:8`, `:8-cli`, etc.)
- [PHP: PHP 8.3 is no more default for :latest tag](https://github.com/jakubboucek/docker-lamp-devstack/commit/0a50fd79ab0f238ec9bde0043961b272df78e86e)