### PR TITLE
PHP: Update to Debian 13 (Trixie) based images & remove IMAP extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ unoptimized, unmaintained)
     [`gd`](https://www.php.net/manual/en/book.image.php) with PNG, WebP, AVIF, FreeType fonts support
     [`gettext`](https://www.php.net/manual/en/book.gettext.php),
     [`gmp`](https://www.php.net/manual/en/book.gmp.php),
-    [`imap`](https://www.php.net/manual/en/book.imap.php) (up to PHP 8.3),
     [`intl`](https://www.php.net/manual/en/book.intl.php),
     [`memcached`](https://www.php.net/manual/en/book.memcached.php),
     [`mysqli`](https://www.php.net/manual/en/book.mysqli.php),
@@ -87,6 +86,14 @@ unoptimized, unmaintained)
 - timezones are correctly supported
 - optimized for small image size and short load times
 
+### Removed extensions
+
+Certain PHP extensions have been intentionally excluded from these images because they are deprecated and interfere with
+compatibility with important updates of other components.
+
+| Package | Available up to                                                                | Reason to remove         |
+|---------|--------------------------------------------------------------------------------|--------------------------|
+| `imap`  | `8.3.24`, `8.2.28`, and `8.1.32`, and remains in legacy images (8.0 and older) | incompatible w/Debian 13 |
 
 ## Basic usage
 Copy the [`docker-compose.yml`](docker-compose.yml) file

--- a/check-pulls.sh
+++ b/check-pulls.sh
@@ -3,16 +3,16 @@
 # shellcheck disable=SC2086
 set -eux;
 
-docker pull php:8.1-cli-bookworm
-docker pull php:8.1-apache-bookworm
-docker pull php:8.2-cli-bookworm
-docker pull php:8.2-apache-bookworm
-docker pull php:8.3-cli-bookworm
-docker pull php:8.3-apache-bookworm
-docker pull php:8.4-cli-bookworm
-docker pull php:8.4-apache-bookworm
-docker pull php:8.5-rc-cli-bookworm
-docker pull php:8.5-rc-apache-bookworm
+docker pull php:8.1-cli-trixie
+docker pull php:8.1-apache-trixie
+docker pull php:8.2-cli-trixie
+docker pull php:8.2-apache-trixie
+docker pull php:8.3-cli-trixie
+docker pull php:8.3-apache-trixie
+docker pull php:8.4-cli-trixie
+docker pull php:8.4-apache-trixie
+docker pull php:8.5-rc-cli-trixie
+docker pull php:8.5-rc-apache-trixie
 
 docker pull mariadb:10.6
 docker pull mariadb:10.11

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -1,4 +1,4 @@
-FROM php:8.1-apache-bookworm
+FROM php:8.1-apache-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.1 (Apache module)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,12 +16,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \
-        libc-client-dev \
         libfreetype6-dev \
         libgmp-dev \
         libicu-dev \
         libjpeg62-turbo-dev \
-        libkrb5-dev \
         libmemcached-dev \
         libpng-dev \
         libsodium-dev \
@@ -32,35 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libc-client2007e \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libgssapi-krb5-2 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libk5crypto3 \
-        libkrb5-3 \
-        libkrb5support0 \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -77,8 +76,6 @@ RUN set -eux; \
         zip; \
     docker-php-ext-configure \
         gd --with-avif --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure \
-        imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install -j$(nproc) \
         bcmath \
         bz2 \
@@ -87,7 +84,6 @@ RUN set -eux; \
         gd \
         gettext \
         gmp \
-        imap \
         intl \
         mysqli \
         opcache \
@@ -107,9 +103,9 @@ RUN set -eux; \
         expires \
         headers \
         rewrite; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -1,4 +1,4 @@
-FROM php:8.1-cli-bookworm
+FROM php:8.1-cli-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.1 (CLI)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,12 +16,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \
-        libc-client-dev \
         libfreetype6-dev \
         libgmp-dev \
         libicu-dev \
         libjpeg62-turbo-dev \
-        libkrb5-dev \
         libmemcached-dev \
         libpng-dev \
         libsodium-dev \
@@ -32,35 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libc-client2007e \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libgssapi-krb5-2 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libk5crypto3 \
-        libkrb5-3 \
-        libkrb5support0 \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -77,8 +76,6 @@ RUN set -eux; \
         zip; \
     docker-php-ext-configure \
         gd --with-avif --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure \
-        imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install -j$(nproc) \
         bcmath \
         bz2 \
@@ -87,7 +84,6 @@ RUN set -eux; \
         gd \
         gettext \
         gmp \
-        imap \
         intl \
         mysqli \
         opcache \
@@ -103,9 +99,9 @@ RUN set -eux; \
         zip; \
     pecl install memcached; \
     docker-php-ext-enable memcached; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -1,4 +1,4 @@
-FROM php:8.2-apache-bookworm
+FROM php:8.2-apache-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.2 (Apache module)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,12 +16,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \
-        libc-client-dev \
         libfreetype6-dev \
         libgmp-dev \
         libicu-dev \
         libjpeg62-turbo-dev \
-        libkrb5-dev \
         libmemcached-dev \
         libpng-dev \
         libsodium-dev \
@@ -32,35 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libc-client2007e \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libgssapi-krb5-2 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libk5crypto3 \
-        libkrb5-3 \
-        libkrb5support0 \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -77,8 +76,6 @@ RUN set -eux; \
         zip; \
     docker-php-ext-configure \
         gd --with-avif --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure \
-        imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install -j$(nproc) \
         bcmath \
         bz2 \
@@ -87,7 +84,6 @@ RUN set -eux; \
         gd \
         gettext \
         gmp \
-        imap \
         intl \
         mysqli \
         opcache \
@@ -107,9 +103,9 @@ RUN set -eux; \
         expires \
         headers \
         rewrite; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-bookworm
+FROM php:8.2-cli-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.2 (CLI)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,12 +16,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \
-        libc-client-dev \
         libfreetype6-dev \
         libgmp-dev \
         libicu-dev \
         libjpeg62-turbo-dev \
-        libkrb5-dev \
         libmemcached-dev \
         libpng-dev \
         libsodium-dev \
@@ -32,35 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libc-client2007e \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libgssapi-krb5-2 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libk5crypto3 \
-        libkrb5-3 \
-        libkrb5support0 \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -77,8 +76,6 @@ RUN set -eux; \
         zip; \
     docker-php-ext-configure \
         gd --with-avif --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure \
-        imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install -j$(nproc) \
         bcmath \
         bz2 \
@@ -87,7 +84,6 @@ RUN set -eux; \
         gd \
         gettext \
         gmp \
-        imap \
         intl \
         mysqli \
         opcache \
@@ -103,9 +99,9 @@ RUN set -eux; \
         zip; \
     pecl install memcached; \
     docker-php-ext-enable memcached; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -1,4 +1,4 @@
-FROM php:8.3-apache-bookworm
+FROM php:8.3-apache-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.3 (Apache module)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,12 +16,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \
-        libc-client-dev \
         libfreetype6-dev \
         libgmp-dev \
         libicu-dev \
         libjpeg62-turbo-dev \
-        libkrb5-dev \
         libmemcached-dev \
         libpng-dev \
         libsodium-dev \
@@ -32,35 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libc-client2007e \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libgssapi-krb5-2 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libk5crypto3 \
-        libkrb5-3 \
-        libkrb5support0 \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -77,8 +76,6 @@ RUN set -eux; \
         zip; \
     docker-php-ext-configure \
         gd --with-avif --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure \
-        imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install -j$(nproc) \
         bcmath \
         bz2 \
@@ -87,7 +84,6 @@ RUN set -eux; \
         gd \
         gettext \
         gmp \
-        imap \
         intl \
         mysqli \
         opcache \
@@ -107,9 +103,9 @@ RUN set -eux; \
         expires \
         headers \
         rewrite; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -1,4 +1,4 @@
-FROM php:8.3-cli-bookworm
+FROM php:8.3-cli-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.3 (CLI)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,12 +16,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \
-        libc-client-dev \
         libfreetype6-dev \
         libgmp-dev \
         libicu-dev \
         libjpeg62-turbo-dev \
-        libkrb5-dev \
         libmemcached-dev \
         libpng-dev \
         libsodium-dev \
@@ -32,35 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libc-client2007e \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libgssapi-krb5-2 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libk5crypto3 \
-        libkrb5-3 \
-        libkrb5support0 \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -77,8 +76,6 @@ RUN set -eux; \
         zip; \
     docker-php-ext-configure \
         gd --with-avif --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure \
-        imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install -j$(nproc) \
         bcmath \
         bz2 \
@@ -87,7 +84,6 @@ RUN set -eux; \
         gd \
         gettext \
         gmp \
-        imap \
         intl \
         mysqli \
         opcache \
@@ -103,9 +99,9 @@ RUN set -eux; \
         zip; \
     pecl install memcached; \
     docker-php-ext-enable memcached; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -1,4 +1,4 @@
-FROM php:8.4-apache-bookworm
+FROM php:8.4-apache-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.4 (Apache module)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -30,30 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -97,9 +103,9 @@ RUN set -eux; \
         expires \
         headers \
         rewrite; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -1,4 +1,4 @@
-FROM php:8.4-cli-bookworm
+FROM php:8.4-cli-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.4 (CLI)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -30,30 +30,36 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libhashkit2 \
-        libicu72 \
+        libgpg-error0 \
+        libhashkit2t64 \
+        libicu76 \
         libjpeg62-turbo \
-        libmemcached11 \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libmemcached11t64 \
+        libpng16-16t64 \
+        librav1e0.7 \
         libsasl2-2 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -93,9 +99,9 @@ RUN set -eux; \
         zip; \
     pecl install memcached; \
     docker-php-ext-enable memcached; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -1,4 +1,4 @@
-FROM php:8.5-rc-apache-bookworm
+FROM php:8.5-rc-apache-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.5 (Pre-release, Apache module)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -30,27 +30,33 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libicu72 \
+        libgpg-error0 \
+        libicu76 \
         libjpeg62-turbo \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libpng16-16t64 \
+        librav1e0.7 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -87,15 +93,15 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+#    pecl install memcached; \
+#    docker-php-ext-enable memcached; \
     a2enmod \
         expires \
         headers \
         rewrite; \
-    pecl clear-cache; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+#    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -1,4 +1,4 @@
-FROM php:8.5-rc-cli-bookworm
+FROM php:8.5-rc-cli-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
 LABEL org.label-schema.name="PHP 8.5 (Pre-release, CLI)"
@@ -8,7 +8,7 @@ LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devst
 WORKDIR /tmp
 
 # Use local mirrors to install Debian updates
-COPY sources.list-bookworm /etc/apt/sources.list
+COPY sources.list-trixie /etc/apt/sources.list
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -30,27 +30,33 @@ ARG EXTENSION_DEV_DEPS=" \
     "
 
 ARG EXTENSION_RUNTIME_DEPS="  \
-        libabsl20220623 \
+        libabsl20240722 \
         libaom3 \
-        libavif15 \
+        libavif16 \
         libbrotli1 \
-        libdav1d6 \
+        libbz2-1.0 \
+        libdav1d7 \
         libfreetype6 \
         libgav1-1 \
         libgcrypt20 \
         libgmp10 \
-        libicu72 \
+        libgpg-error0 \
+        libicu76 \
         libjpeg62-turbo \
-        libpng16-16 \
-        librav1e0 \
+        liblzma5 \
+        libpng16-16t64 \
+        librav1e0.7 \
+        libsharpyuv0 \
         libsodium23 \
-        libssl3 \
-        libsvtav1enc1 \
+        libssl3t64 \
+        libsvtav1enc2 \
         libwebp7 \
         libxml2 \
         libxslt1.1 \
         libyuv0 \
-        libzip4 \
+        libzip5 \
+        libzstd1 \
+        zlib1g \
     "
 
 # OS binaries install && update critical binaries
@@ -87,11 +93,11 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-  #  pecl install memcached; \
-  #  docker-php-ext-enable memcached; \
-  #  pecl clear-cache; \
+#    pecl install memcached; \
+#    docker-php-ext-enable memcached; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
+#    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/build-php-8.1-cli.sh
+++ b/php/build-php-8.1-cli.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.1
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.1-cli-bookworm
-    docker run --rm php:8.1-cli-bookworm php --version
+    docker pull php:8.1-cli-trixie
+    docker run --rm php:8.1-cli-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.1.sh
+++ b/php/build-php-8.1.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.1
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.1-apache-bookworm
-    docker run --rm php:8.1-apache-bookworm php --version
+    docker pull php:8.1-apache-trixie
+    docker run --rm php:8.1-apache-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.2-cli.sh
+++ b/php/build-php-8.2-cli.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.2
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.2-cli-bookworm
-    docker run --rm php:8.2-cli-bookworm php --version
+    docker pull php:8.2-cli-trixie
+    docker run --rm php:8.2-cli-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.2.sh
+++ b/php/build-php-8.2.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.2
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.2-apache-bookworm
-    docker run --rm php:8.2-apache-bookworm php --version
+    docker pull php:8.2-apache-trixie
+    docker run --rm php:8.2-apache-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.3-cli.sh
+++ b/php/build-php-8.3-cli.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.3
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.3-cli-bookworm
-    docker run --rm php:8.3-cli-bookworm php --version
+    docker pull php:8.3-cli-trixie
+    docker run --rm php:8.3-cli-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.3.sh
+++ b/php/build-php-8.3.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.3
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.3-apache-bookworm
-    docker run --rm php:8.3-apache-bookworm php --version
+    docker pull php:8.3-apache-trixie
+    docker run --rm php:8.3-apache-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.4-cli.sh
+++ b/php/build-php-8.4-cli.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.4-cli-bookworm
-    docker run --rm php:8.4-cli-bookworm php --version
+    docker pull php:8.4-cli-trixie
+    docker run --rm php:8.4-cli-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.4.sh
+++ b/php/build-php-8.4.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.4-apache-bookworm
-    docker run --rm php:8.4-apache-bookworm php --version
+    docker pull php:8.4-apache-trixie
+    docker run --rm php:8.4-apache-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.5-cli.sh
+++ b/php/build-php-8.5-cli.sh
@@ -8,8 +8,8 @@ cd "$(dirname $0)";
 ### PHP 8.5
 
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.5-rc-cli-bookworm
-    docker run --rm php:8.5-rc-cli-bookworm php --version
+    docker pull php:8.5-rc-cli-trixie
+    docker run --rm php:8.5-rc-cli-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/build-php-8.5.sh
+++ b/php/build-php-8.5.sh
@@ -7,8 +7,8 @@ cd "$(dirname $0)";
 
 ### PHP 8.5
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.5-rc-apache-bookworm
-    docker run --rm php:8.5-rc-apache-bookworm php --version
+    docker pull php:8.5-rc-apache-trixie
+    docker run --rm php:8.5-rc-apache-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then

--- a/php/sources.list-bookworm
+++ b/php/sources.list-bookworm
@@ -1,3 +1,0 @@
-deb http://ftp.cz.debian.org/debian bookworm main
-deb http://security.debian.org/debian-security bookworm-security main
-deb http://ftp.cz.debian.org/debian bookworm-updates main

--- a/php/sources.list-trixie
+++ b/php/sources.list-trixie
@@ -1,0 +1,3 @@
+deb http://ftp.cz.debian.org/debian trixie main
+deb http://security.debian.org/debian-security trixie-security main
+deb http://ftp.cz.debian.org/debian trixie-updates main


### PR DESCRIPTION
This PR upgrades PHP images to Debian 13 (Trixie) linux, see more info at: docker-library/php#1596

## Remove IMAP extension

Extension `imap` is marked as Deprecated and now is incompatible with Trixie (docker-library/php#1610). It was decided to remove him from images. Extension will be available only in older images up to: `8.3.24`, `8.2.28`, and `8.1.32`, and remains in legacy images (8.0 and older).

## BC Breaks

- Removed `imap` extension – see reasons above