### PR TITLE
PHP 8.5 is now stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ of base images designed to cover most standard development workflows — with no
 
 ## Main features
 - architecture: `linux/amd64`
-- current **PHP** versions: 8.4, 8.3, 8.2 and 8.1 and pre-release of 8.5
+- current **PHP** versions: 8.5, 8.4, 8.3, 8.2 and 8.1
 - unsupported **PHP** versions also available: 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5 and 5.4 (with limited stability,
-unoptimized, unmaintained)
+    unoptimized, unmaintained)
 - current versions of **MariaDB** 12.0, 11.8, 11.4, 10.11, 10.6  and RC pre-release of 12.1
 - unsupported versions of **MariaDB** 11.7, 11.6, 11.5, 11.3, 11.2, 11.1, 11.0, 10.10, 10.9, 10.8, 10.7, 10.5, 10.4
   and 10.3 (unmaintained)
@@ -123,8 +123,8 @@ my_project/                 <-- project's root
 Images are tagged by the cascaded SemVer:
 - `jakubboucek/lamp-devstack-php:latest` – means `latest` available stable PHP image,
 - `jakubboucek/lamp-devstack-php:8` – represents the highest PHP image of `8` version, but lower than `9.0.0`,
-- `jakubboucek/lamp-devstack-php:8.4` – represents the highest PHP image of `8.4` version, but lower than `8.5.0`,
-- `jakubboucek/lamp-devstack-php:8.4.0` – represents most specific PHP image, directly version `8.4.0`.
+- `jakubboucek/lamp-devstack-php:8.5` – represents the highest PHP image of `8.5` version, but lower than `8.6.0`,
+- `jakubboucek/lamp-devstack-php:8.5.0` – represents most specific PHP image, directly version `8.5.0`.
 
 **Legacy PHP** images are tagged using different strategy, only latest revision for each minor version is available,
 use `-legacy` tag suffix:
@@ -141,25 +141,21 @@ use `-legacy` tag suffix:
 
 > Note: Version 5.4 is using `-fixed` suffix because is unable to rebuild them from scratch.
 
-> Note: (Pre-release of PHP 8.5 contains unstable version of Xdebug)
+> Note: (Image of PHP 8.5 contains unstable version of Xdebug)
 
 All PHP images have alternative variants with XDebug extension preinstalled, use `-debug` tag suffix, example:
 - `jakubboucek/lamp-devstack-php:debug`
 - `jakubboucek/lamp-devstack-php:8-debug`
-- `jakubboucek/lamp-devstack-php:8.4-debug`
-- `jakubboucek/lamp-devstack-php:8.4.0-debug`
+- `jakubboucek/lamp-devstack-php:8.5-debug`
+- `jakubboucek/lamp-devstack-php:8.5.0-debug`
 - `jakubboucek/lamp-devstack-php:7.4-legacy-debug`
 
 All PHP images also have alternative CLI variants, use `-cli` tag suffix, example:
 - `jakubboucek/lamp-devstack-php:cli`
 - `jakubboucek/lamp-devstack-php:8-cli`
-- `jakubboucek/lamp-devstack-php:8.4-cli`
-- `jakubboucek/lamp-devstack-php:8.4.0-cli`
+- `jakubboucek/lamp-devstack-php:8.5-cli`
+- `jakubboucek/lamp-devstack-php:8.5.0-cli`
 - `jakubboucek/lamp-devstack-php:7.4-legacy-cli`
-
-The pre-release of PHP 8.5 images have the `-rc` suffix, example:
-- `jakubboucek/lamp-devstack-php:8.5-rc`
-- `jakubboucek/lamp-devstack-php:8.5-rc-cli`
 
 ### Using MySQL
 MySQL server starts at the same time as the web server.

--- a/check-pulls.sh
+++ b/check-pulls.sh
@@ -11,8 +11,8 @@ docker pull php:8.3-cli-trixie
 docker pull php:8.3-apache-trixie
 docker pull php:8.4-cli-trixie
 docker pull php:8.4-apache-trixie
-docker pull php:8.5-rc-cli-trixie
-docker pull php:8.5-rc-apache-trixie
+docker pull php:8.5-cli-trixie
+docker pull php:8.5-apache-trixie
 
 docker pull mariadb:10.6
 docker pull mariadb:10.11

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -1,7 +1,7 @@
-FROM php:8.5-rc-apache-trixie
+FROM php:8.5-apache-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
-LABEL org.label-schema.name="PHP 8.5 (Pre-release, Apache module)"
+LABEL org.label-schema.name="PHP 8.5 (Apache module)"
 LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devstack"
 
 # Workdir during installation

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -1,7 +1,7 @@
-FROM php:8.5-rc-cli-trixie
+FROM php:8.5-cli-trixie
 
 LABEL maintainer="Jakub Bouček <pan@jakubboucek.cz>"
-LABEL org.label-schema.name="PHP 8.5 (Pre-release, CLI)"
+LABEL org.label-schema.name="PHP 8.5 (CLI)"
 LABEL org.label-schema.vcs-url="https://github.com/jakubboucek/docker-lamp-devstack"
 
 # Workdir during installation

--- a/php/Dockerfile-8.5-debug
+++ b/php/Dockerfile-8.5-debug
@@ -1,6 +1,6 @@
-FROM jakubboucek/lamp-devstack-php:8.5-rc
+FROM jakubboucek/lamp-devstack-php:8.5
 
-LABEL org.label-schema.name="PHP 8.5 (Pre-release, Apache module + Xdebug)"
+LABEL org.label-schema.name="PHP 8.5 (Apache module + Xdebug pre-release)"
 
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/build-php-8.4-cli.sh
+++ b/php/build-php-8.4-cli.sh
@@ -14,8 +14,6 @@ fi
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
     docker build --progress plain -f ./Dockerfile-8.4-cli -t jakubboucek/lamp-devstack-php:8.4-cli ./
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-cli php -r "echo PHP_RELEASE_VERSION;")
-    docker tag jakubboucek/lamp-devstack-php:8.4-cli jakubboucek/lamp-devstack-php:cli
-    docker tag jakubboucek/lamp-devstack-php:8.4-cli jakubboucek/lamp-devstack-php:8-cli
     docker tag jakubboucek/lamp-devstack-php:8.4-cli jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-cli
 fi
 
@@ -29,6 +27,4 @@ if [ "${NO_PUSH:-0}" -ne "1" ]; then
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4-cli php -r "echo PHP_RELEASE_VERSION;")
     docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-cli
     docker push jakubboucek/lamp-devstack-php:8.4-cli
-    docker push jakubboucek/lamp-devstack-php:8-cli
-    docker push jakubboucek/lamp-devstack-php:cli
 fi

--- a/php/build-php-8.4.sh
+++ b/php/build-php-8.4.sh
@@ -15,11 +15,7 @@ if [ "${NO_BUILD:-0}" -ne "1" ]; then
     docker build --progress plain -f ./Dockerfile-8.4 -t jakubboucek/lamp-devstack-php:8.4 ./
     docker build --progress plain -f ./Dockerfile-8.4-debug -t jakubboucek/lamp-devstack-php:8.4-debug ./
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4 php -r "echo PHP_RELEASE_VERSION;")
-    docker tag jakubboucek/lamp-devstack-php:8.4 jakubboucek/lamp-devstack-php:8
-    docker tag jakubboucek/lamp-devstack-php:8.4 jakubboucek/lamp-devstack-php:latest
     docker tag jakubboucek/lamp-devstack-php:8.4 jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}
-    docker tag jakubboucek/lamp-devstack-php:8.4-debug jakubboucek/lamp-devstack-php:debug
-    docker tag jakubboucek/lamp-devstack-php:8.4-debug jakubboucek/lamp-devstack-php:8-debug
     docker tag jakubboucek/lamp-devstack-php:8.4-debug jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-debug
 fi
 
@@ -35,10 +31,6 @@ if [ "${NO_PUSH:-0}" -ne "1" ]; then
     PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.4 php -r "echo PHP_RELEASE_VERSION;")
     docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}-debug
     docker push jakubboucek/lamp-devstack-php:8.4-debug
-    docker push jakubboucek/lamp-devstack-php:8-debug
-    docker push jakubboucek/lamp-devstack-php:debug
     docker push jakubboucek/lamp-devstack-php:8.4.${PHP_RELEASE}
     docker push jakubboucek/lamp-devstack-php:8.4
-    docker push jakubboucek/lamp-devstack-php:8
-    docker push jakubboucek/lamp-devstack-php:latest
 fi

--- a/php/build-php-8.5-cli.sh
+++ b/php/build-php-8.5-cli.sh
@@ -8,28 +8,28 @@ cd "$(dirname $0)";
 ### PHP 8.5
 
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.5-rc-cli-trixie
-    docker run --rm php:8.5-rc-cli-trixie php --version
+    docker pull php:8.5-cli-trixie
+    docker run --rm php:8.5-cli-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
-    docker build --progress plain -f ./Dockerfile-8.5-cli -t jakubboucek/lamp-devstack-php:8.5-rc-cli ./
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-cli php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-cli php -r "echo PHP_EXTRA_VERSION;")
-    docker tag jakubboucek/lamp-devstack-php:8.5-rc-cli jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-cli
-    docker tag jakubboucek/lamp-devstack-php:8.5-rc-cli jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}-cli
+    docker build --progress plain -f ./Dockerfile-8.5-cli -t jakubboucek/lamp-devstack-php:8.5-cli ./
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-cli php -r "echo PHP_RELEASE_VERSION;")
+    docker tag jakubboucek/lamp-devstack-php:8.5-cli jakubboucek/lamp-devstack-php:cli
+    docker tag jakubboucek/lamp-devstack-php:8.5-cli jakubboucek/lamp-devstack-php:8-cli
+    docker tag jakubboucek/lamp-devstack-php:8.5-cli jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-cli
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-cli php --version
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-cli php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-cli php -r "var_export(gd_info()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.5-cli php --version
+    docker run --rm jakubboucek/lamp-devstack-php:8.5-cli php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.5-cli php -r "var_export(gd_info()) . PHP_EOL;"
 fi
 
 if [ "${NO_PUSH:-0}" -ne "1" ]; then
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-cli php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-cli php -r "echo PHP_EXTRA_VERSION;")
-    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}-cli
-    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-cli
-    docker push jakubboucek/lamp-devstack-php:8.5-rc-cli
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-cli php -r "echo PHP_RELEASE_VERSION;")
+    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-cli
+    docker push jakubboucek/lamp-devstack-php:8.5-cli
+    docker push jakubboucek/lamp-devstack-php:8-cli
+    docker push jakubboucek/lamp-devstack-php:cli
 fi

--- a/php/build-php-8.5.sh
+++ b/php/build-php-8.5.sh
@@ -7,36 +7,38 @@ cd "$(dirname $0)";
 
 ### PHP 8.5
 if [ "${NO_PULL:-0}" -ne "1" ]; then
-    docker pull php:8.5-rc-apache-trixie
-    docker run --rm php:8.5-rc-apache-trixie php --version
+    docker pull php:8.5-apache-trixie
+    docker run --rm php:8.5-apache-trixie php --version
 fi
 
 if [ "${NO_BUILD:-0}" -ne "1" ]; then
-    docker build --progress plain -f ./Dockerfile-8.5 -t jakubboucek/lamp-devstack-php:8.5-rc ./
-    docker build --progress plain -f ./Dockerfile-8.5-debug -t jakubboucek/lamp-devstack-php:8.5-rc-debug ./
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc php -r "echo PHP_EXTRA_VERSION;")
-    docker tag jakubboucek/lamp-devstack-php:8.5-rc jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc
-    docker tag jakubboucek/lamp-devstack-php:8.5-rc jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}
-    docker tag jakubboucek/lamp-devstack-php:8.5-rc-debug jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-debug
-    docker tag jakubboucek/lamp-devstack-php:8.5-rc-debug jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-debug-${PHP_RELEASE_EXTRA}
+    docker build --progress plain -f ./Dockerfile-8.5 -t jakubboucek/lamp-devstack-php:8.5 ./
+    docker build --progress plain -f ./Dockerfile-8.5-debug -t jakubboucek/lamp-devstack-php:8.5-debug ./
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5 php -r "echo PHP_RELEASE_VERSION;")
+    docker tag jakubboucek/lamp-devstack-php:8.5 jakubboucek/lamp-devstack-php:latest
+    docker tag jakubboucek/lamp-devstack-php:8.5 jakubboucek/lamp-devstack-php:8
+    docker tag jakubboucek/lamp-devstack-php:8.5 jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}
+    docker tag jakubboucek/lamp-devstack-php:8.5-debug jakubboucek/lamp-devstack-php:debug
+    docker tag jakubboucek/lamp-devstack-php:8.5-debug jakubboucek/lamp-devstack-php:8-debug
+    docker tag jakubboucek/lamp-devstack-php:8.5-debug jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-debug
 fi
 
 if [ "${NO_TEST:-0}" -ne "1" ]; then
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc php --version
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-debug php --version
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc-debug php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
-    docker run --rm jakubboucek/lamp-devstack-php:8.5-rc php -r "var_export(gd_info()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.5 php --version
+    docker run --rm jakubboucek/lamp-devstack-php:8.5-debug php --version
+    docker run --rm jakubboucek/lamp-devstack-php:8.5 php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.5-debug php -r "echo implode(', ', get_loaded_extensions()) . PHP_EOL;"
+    docker run --rm jakubboucek/lamp-devstack-php:8.5 php -r "var_export(gd_info()) . PHP_EOL;"
 fi
 
 if [ "${NO_PUSH:-0}" -ne "1" ]; then
-    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc php -r "echo PHP_RELEASE_VERSION;")
-    PHP_RELEASE_EXTRA=$(docker run --rm jakubboucek/lamp-devstack-php:8.5-rc php -r "echo PHP_EXTRA_VERSION;")
-    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-${PHP_RELEASE_EXTRA}
-    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc
-    docker push jakubboucek/lamp-devstack-php:8.5-rc
-    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-debug-${PHP_RELEASE_EXTRA}
-    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-rc-debug
-    docker push jakubboucek/lamp-devstack-php:8.5-rc-debug
+    PHP_RELEASE=$(docker run --rm jakubboucek/lamp-devstack-php:8.5 php -r "echo PHP_RELEASE_VERSION;")
+    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}-debug
+    docker push jakubboucek/lamp-devstack-php:8.5-debug
+    docker push jakubboucek/lamp-devstack-php:8-debug
+    docker push jakubboucek/lamp-devstack-php:debug
+    docker push jakubboucek/lamp-devstack-php:8.5.${PHP_RELEASE}
+    docker push jakubboucek/lamp-devstack-php:8.5
+    docker push jakubboucek/lamp-devstack-php:8
+    docker push jakubboucek/lamp-devstack-php:latest
 fi

--- a/test-php.sh
+++ b/test-php.sh
@@ -13,5 +13,5 @@ docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.3 c
 docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.3-cli composer -d tools/ test;
 docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.4 composer -d tools/ test;
 docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.4-cli composer -d tools/ test;
-docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.5-rc composer -d tools/ test;
-docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.5-rc-cli composer -d tools/ test;
+docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.5 composer -d tools/ test;
+docker run --rm -it -v "$(pwd)":/app -w /app jakubboucek/lamp-devstack-php:8.5-cli composer -d tools/ test;


### PR DESCRIPTION
- Change RC channel to stable channel on PHP 8.5
- Move docker tags `latest`, `cli`, `debug`, `8-cli` and `8-debug` from 8.4 to 8.5.
