### PR TITLE
PHP: update Xdebug to stable for PHP 8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,6 @@ use `-legacy` tag suffix:
 
 > Note: Version 5.4 is using `-fixed` suffix because is unable to rebuild them from scratch.
 
-> Note: (Image of PHP 8.5 contains unstable version of Xdebug)
-
 All PHP images have alternative variants with XDebug extension preinstalled, use `-debug` tag suffix, example:
 - `jakubboucek/lamp-devstack-php:debug`
 - `jakubboucek/lamp-devstack-php:8-debug`

--- a/php/Dockerfile-8.5-debug
+++ b/php/Dockerfile-8.5-debug
@@ -10,12 +10,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /tmp
 
-# Install Xdebug (Pre-release version)
+# Install Xdebug
 RUN set -eux; \
-    curl https://xdebug.org/files/xdebug-3.5.0alpha3.tgz -o xdebug-3.5.0alpha3.tgz; \
-    tar -xzf xdebug-3.5.0alpha3.tgz; \
-    rm xdebug-3.5.0alpha3.tgz; \
-    cd xdebug-3.5.0alpha3; \
+    curl https://xdebug.org/files/xdebug-3.5.0.tgz -o xdebug-3.5.0.tgz; \
+    tar -xzf xdebug-3.5.0.tgz; \
+    rm xdebug-3.5.0.tgz; \
+    cd xdebug-3.5.0; \
     phpize; \
     ./configure --enable-xdebug; \
     make -j$(nproc); \


### PR DESCRIPTION
Update Xdebug for PHP 8.5 to stable channel.

[WIP] Still not using PECL because it's [not already released](https://pecl.php.net/package/xdebug).