### PR TITLE
Add PIE - The PHP Installer for Extensions

### DIFF
--- a/check-pulls.sh
+++ b/check-pulls.sh
@@ -14,6 +14,8 @@ docker pull php:8.4-apache-trixie
 docker pull php:8.5-cli-trixie
 docker pull php:8.5-apache-trixie
 
+docker pull ghcr.io/php/pie:bin
+
 docker pull mariadb:10.6
 docker pull mariadb:10.11
 docker pull mariadb:11.4

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -13,6 +13,9 @@ COPY sources.list-trixie /etc/apt/sources.list
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install PIE - The modern PHP Installer for Extensions
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \
         libbz2-dev \

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -10,11 +10,11 @@ WORKDIR /tmp
 # Use local mirrors to install Debian updates
 COPY sources.list-trixie /etc/apt/sources.list
 
-# Prevent interactive block
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+# Prevent interactive block
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG EXTENSION_DEV_DEPS=" \
         libavif-dev \

--- a/php/build-php-8.1-cli.sh
+++ b/php/build-php-8.1-cli.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.1
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.1-cli-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.1-cli-trixie php --version
 fi
 

--- a/php/build-php-8.1.sh
+++ b/php/build-php-8.1.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.1
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.1-apache-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.1-apache-trixie php --version
 fi
 

--- a/php/build-php-8.2-cli.sh
+++ b/php/build-php-8.2-cli.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.2
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.2-cli-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.2-cli-trixie php --version
 fi
 

--- a/php/build-php-8.2.sh
+++ b/php/build-php-8.2.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.2
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.2-apache-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.2-apache-trixie php --version
 fi
 

--- a/php/build-php-8.3-cli.sh
+++ b/php/build-php-8.3-cli.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.3
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.3-cli-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.3-cli-trixie php --version
 fi
 

--- a/php/build-php-8.3.sh
+++ b/php/build-php-8.3.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.3
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.3-apache-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.3-apache-trixie php --version
 fi
 

--- a/php/build-php-8.4-cli.sh
+++ b/php/build-php-8.4-cli.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.4-cli-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.4-cli-trixie php --version
 fi
 

--- a/php/build-php-8.4.sh
+++ b/php/build-php-8.4.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.4-apache-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.4-apache-trixie php --version
 fi
 

--- a/php/build-php-8.5-cli.sh
+++ b/php/build-php-8.5-cli.sh
@@ -9,6 +9,7 @@ cd "$(dirname $0)";
 
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.5-cli-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.5-cli-trixie php --version
 fi
 

--- a/php/build-php-8.5.sh
+++ b/php/build-php-8.5.sh
@@ -8,6 +8,7 @@ cd "$(dirname $0)";
 ### PHP 8.5
 if [ "${NO_PULL:-0}" -ne "1" ]; then
     docker pull php:8.5-apache-trixie
+    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.5-apache-trixie php --version
 fi
 


### PR DESCRIPTION
This PR is adding PIE to images ([The PHP Installer for Extensions](https://github.com/php/pie)).

This is NOT replacing PECL/PEAR and NOT change `docker-php-ext-install` behavior (as mentioned at docker-library/php#1554). Only add new DEV tool to image.