### PR TITLE
PHP: Replace PECL installer with PIE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/docker
+/.docker
+/php/build
 /tools/composer.lock
 /tools/vendor

--- a/build-php.sh
+++ b/build-php.sh
@@ -5,7 +5,7 @@ set -eux;
 
 cd "$(dirname $0)";
 
-./prepare-assets.sh
+[ "${NO_PULL:-0}" -ne 1 ] && [ "${NO_ASSETS:-0}" -ne 1 ] && ./prepare-assets.sh
 
 export NO_ASSETS=1
 

--- a/build-php.sh
+++ b/build-php.sh
@@ -5,6 +5,10 @@ set -eux;
 
 cd "$(dirname $0)";
 
+./prepare-assets.sh
+
+export NO_ASSETS=1
+
 ./php/build-php-8.1-cli.sh
 ./php/build-php-8.1.sh
 ./php/build-php-8.2-cli.sh

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -156,7 +156,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,15 +102,13 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     a2enmod \
         expires \
         headers \
         rewrite; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -112,7 +112,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -156,7 +156,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,11 +102,9 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -108,7 +108,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -143,7 +143,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.1-cli
+++ b/php/Dockerfile-8.1-cli
@@ -143,7 +143,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.1-debug
+++ b/php/Dockerfile-8.1-debug
@@ -5,12 +5,13 @@ LABEL org.label-schema.name="PHP 8.1 (Apache module + Xdebug)"
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
+# Setup PIE working directory
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
+
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
-    pecl install xdebug; \
-    pecl clear-cache; \
-    docker-php-ext-enable xdebug; \
+    pie install xdebug/xdebug; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -157,7 +157,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,15 +102,13 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     a2enmod \
         expires \
         headers \
         rewrite; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -112,7 +112,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -157,7 +157,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,11 +102,9 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -108,7 +108,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -144,7 +144,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.2-cli
+++ b/php/Dockerfile-8.2-cli
@@ -144,7 +144,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.2-debug
+++ b/php/Dockerfile-8.2-debug
@@ -5,12 +5,13 @@ LABEL org.label-schema.name="PHP 8.2 (Apache module + Xdebug)"
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
+# Setup PIE working directory
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
+
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
-    pecl install xdebug; \
-    pecl clear-cache; \
-    docker-php-ext-enable xdebug; \
+    pie install xdebug/xdebug; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -157,7 +157,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,15 +102,13 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     a2enmod \
         expires \
         headers \
         rewrite; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -112,7 +112,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -157,7 +157,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,11 +102,9 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -108,7 +108,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -144,7 +144,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.3-cli
+++ b/php/Dockerfile-8.3-cli
@@ -144,7 +144,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.3-debug
+++ b/php/Dockerfile-8.3-debug
@@ -5,12 +5,13 @@ LABEL org.label-schema.name="PHP 8.3 (Apache module + Xdebug)"
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
+# Setup PIE working directory
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
+
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
-    pecl install xdebug; \
-    pecl clear-cache; \
-    docker-php-ext-enable xdebug; \
+    pie install xdebug/xdebug; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -157,7 +157,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,15 +102,13 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     a2enmod \
         expires \
         headers \
         rewrite; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.4
+++ b/php/Dockerfile-8.4
@@ -112,7 +112,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -157,7 +157,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -101,11 +102,9 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -108,7 +108,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -144,7 +144,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.4-cli
+++ b/php/Dockerfile-8.4-cli
@@ -144,7 +144,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.4-debug
+++ b/php/Dockerfile-8.4-debug
@@ -5,12 +5,13 @@ LABEL org.label-schema.name="PHP 8.4 (Apache module + Xdebug)"
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
+# Setup PIE working directory
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
+
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
-    pecl install xdebug; \
-    pecl clear-cache; \
-    docker-php-ext-enable xdebug; \
+    pie install xdebug/xdebug; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -154,7 +154,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -98,15 +99,13 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     a2enmod \
         expires \
         headers \
         rewrite; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.5
+++ b/php/Dockerfile-8.5
@@ -109,7 +109,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -154,7 +154,7 @@ RUN set -eux; \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!:80>!:${PORT}>!g' /etc/apache2/sites-available/*.conf; \
     sed -ri -e 's!Listen 80!Listen ${PORT}!g' /etc/apache2/ports.conf; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -105,7 +105,7 @@ RUN set -eux; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
-    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*;
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
 
 # Configure Apache & PHP
 # 32767 = E_ALL
@@ -141,7 +141,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
+    rm -rf /tmp/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
-COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY build/pie.phar /usr/bin/pie
 ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -12,6 +12,7 @@ COPY sources.list-trixie /etc/apt/sources.list
 
 # Install PIE - The modern PHP Installer for Extensions
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -98,11 +99,9 @@ RUN set -eux; \
         sysvshm \
         xsl \
         zip; \
-    pecl install memcached; \
-    docker-php-ext-enable memcached; \
+    pie install php-memcached/php-memcached; \
     apt-mark manual ${EXTENSION_RUNTIME_DEPS}; \
     apt-get purge -y --auto-remove ${EXTENSION_DEV_DEPS}; \
-    pecl clear-cache; \
     apt-get clean -y && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \

--- a/php/Dockerfile-8.5-cli
+++ b/php/Dockerfile-8.5-cli
@@ -141,7 +141,7 @@ RUN set -eux; \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
     COMPOSER_BIN_DIR=$(composer global config bin-dir --absolute) 2>/dev/null; \
     echo "export PATH=${COMPOSER_BIN_DIR}:\${PATH}" >> ~/.bashrc; \
-    rm -rf /tmp/*;
+    rm -rf /tmp/* $(composer global config cache-dir --absolute)/*;
 
 # Workdir after installation
 WORKDIR /

--- a/php/Dockerfile-8.5-debug
+++ b/php/Dockerfile-8.5-debug
@@ -1,9 +1,12 @@
 FROM jakubboucek/lamp-devstack-php:8.5
 
-LABEL org.label-schema.name="PHP 8.5 (Apache module + Xdebug pre-release)"
+LABEL org.label-schema.name="PHP 8.5 (Apache module + Xdebug)"
 
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+
+# Setup PIE working directory
+ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
@@ -12,16 +15,8 @@ WORKDIR /tmp
 
 # Install Xdebug
 RUN set -eux; \
-    curl https://xdebug.org/files/xdebug-3.5.0.tgz -o xdebug-3.5.0.tgz; \
-    tar -xzf xdebug-3.5.0.tgz; \
-    rm xdebug-3.5.0.tgz; \
-    cd xdebug-3.5.0; \
-    phpize; \
-    ./configure --enable-xdebug; \
-    make -j$(nproc); \
-    make install; \
-    docker-php-ext-enable xdebug; \
-    rm -rf /tmp/*;
+    pie install xdebug/xdebug; \
+    rm -rf /var/tmp/* /tmp/*;
 
 # Workdir after installation
 WORKDIR /var/www/html

--- a/php/build-php-8.1-cli.sh
+++ b/php/build-php-8.1-cli.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.1
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.1-cli-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.1-cli-trixie php --version
 fi
 

--- a/php/build-php-8.1.sh
+++ b/php/build-php-8.1.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.1
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.1-apache-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.1-apache-trixie php --version
 fi
 

--- a/php/build-php-8.2-cli.sh
+++ b/php/build-php-8.2-cli.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.2
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.2-cli-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.2-cli-trixie php --version
 fi
 

--- a/php/build-php-8.2.sh
+++ b/php/build-php-8.2.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.2
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.2-apache-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.2-apache-trixie php --version
 fi
 

--- a/php/build-php-8.3-cli.sh
+++ b/php/build-php-8.3-cli.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.3
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.3-cli-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.3-cli-trixie php --version
 fi
 

--- a/php/build-php-8.3.sh
+++ b/php/build-php-8.3.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.3
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.3-apache-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.3-apache-trixie php --version
 fi
 

--- a/php/build-php-8.4-cli.sh
+++ b/php/build-php-8.4-cli.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.4-cli-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.4-cli-trixie php --version
 fi
 

--- a/php/build-php-8.4.sh
+++ b/php/build-php-8.4.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.4
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.4-apache-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.4-apache-trixie php --version
 fi
 

--- a/php/build-php-8.5-cli.sh
+++ b/php/build-php-8.5-cli.sh
@@ -10,7 +10,7 @@ if [ "${NO_PULL:-0}" -ne "1" ]; then
     if [ "${NO_ASSETS:-0}" -ne "1" ]; then
         ../prepare-assets.sh
     fi
-    
+
     docker pull php:8.5-cli-trixie
     docker run --rm php:8.5-cli-trixie php --version
 fi

--- a/php/build-php-8.5-cli.sh
+++ b/php/build-php-8.5-cli.sh
@@ -6,10 +6,12 @@ set -eux;
 cd "$(dirname $0)";
 
 ### PHP 8.5
-
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+    
     docker pull php:8.5-cli-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.5-cli-trixie php --version
 fi
 

--- a/php/build-php-8.5.sh
+++ b/php/build-php-8.5.sh
@@ -7,8 +7,11 @@ cd "$(dirname $0)";
 
 ### PHP 8.5
 if [ "${NO_PULL:-0}" -ne "1" ]; then
+    if [ "${NO_ASSETS:-0}" -ne "1" ]; then
+        ../prepare-assets.sh
+    fi
+
     docker pull php:8.5-apache-trixie
-    docker pull ghcr.io/php/pie:bin
     docker run --rm php:8.5-apache-trixie php --version
 fi
 

--- a/prepare-assets.sh
+++ b/prepare-assets.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# shellcheck disable=SC2086
+set -eux;
+
+cd "$(dirname $0)";
+
+mkdir -p php/build
+
+curl -L https://github.com/php/pie/releases/latest/download/pie.phar -o php/build/pie.phar
+
+# Compress the PHAR file to reduce its size
+php -d phar.readonly=0 -r "
+\$phar = new Phar('php/build/pie.phar');
+\$phar->compressFiles(Phar::GZ);
+"
+
+chmod +x php/build/pie.phar

--- a/prepare-assets.sh
+++ b/prepare-assets.sh
@@ -9,10 +9,22 @@ mkdir -p php/build
 
 curl -L https://github.com/php/pie/releases/latest/download/pie.phar -o php/build/pie.phar
 
+# Check that PHP is available
+if ! command -v php >/dev/null 2>&1; then
+    echo "Error: PHP is not installed or not in PATH." >&2
+    exit 1
+fi
+
+# Check that the PHAR file was downloaded successfully and is not empty
+if [ ! -s php/build/pie.phar ]; then
+    echo "Error: Failed to download pie.phar or file is empty." >&2
+    exit 1
+fi
+
 # Compress the PHAR file to reduce its size
 php -d phar.readonly=0 -r "
 \$phar = new Phar('php/build/pie.phar');
 \$phar->compressFiles(Phar::GZ);
-"
+" || { echo "Error: PHP compression step failed." >&2; exit 1; }
 
 chmod +x php/build/pie.phar

--- a/prepare-assets.sh
+++ b/prepare-assets.sh
@@ -7,7 +7,7 @@ cd "$(dirname $0)";
 
 mkdir -p php/build
 
-curl -L https://github.com/php/pie/releases/latest/download/pie.phar -o php/build/pie.phar
+curl -fL https://github.com/php/pie/releases/latest/download/pie.phar -o php/build/pie.phar
 
 # Check that PHP is available
 if ! command -v php >/dev/null 2>&1; then


### PR DESCRIPTION
This PR is replacing PECL as PHP Extension installer with the modern one: PIE.

This is related with #88.