### PR TITLE
PHP: Add SPX extension to debug images

### DIFF
--- a/php/Dockerfile-8.1-debug
+++ b/php/Dockerfile-8.1-debug
@@ -13,5 +13,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y zlib1g-dev; \
     pie install xdebug/xdebug; \
+    pie install noisebynorthwest/php-spx; \
+    apt-get remove --purge -y zlib1g-dev; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.1-debug
+++ b/php/Dockerfile-8.1-debug
@@ -18,4 +18,7 @@ RUN set -eux; \
     pie install xdebug/xdebug; \
     pie install noisebynorthwest/php-spx; \
     apt-get remove --purge -y zlib1g-dev; \
-    rm -rf /var/tmp/* /tmp/*;
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;

--- a/php/Dockerfile-8.1-debug
+++ b/php/Dockerfile-8.1-debug
@@ -14,7 +14,7 @@ ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install Xdebug
+# Install Xdebug and SPX
 RUN set -eux; \
     apt-get update; \
     apt-get install --no-install-recommends -y zlib1g-dev; \

--- a/php/Dockerfile-8.1-debug
+++ b/php/Dockerfile-8.1-debug
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+
 FROM jakubboucek/lamp-devstack-php:8.1
 
 LABEL org.label-schema.name="PHP 8.1 (Apache module + Xdebug)"
@@ -22,3 +25,10 @@ RUN set -eux; \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
     rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
+
+# Configure OPcache
+ENV PHP_SPX_ENABLED=0
+ENV PHP_SPX_HTTP_KEY="dev"
+ENV PHP_SPX_HTTP_IP_WHITELIST="*"
+
+COPY spx.ini /usr/local/etc/php/conf.d/spx.ini

--- a/php/Dockerfile-8.2-debug
+++ b/php/Dockerfile-8.2-debug
@@ -13,5 +13,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y zlib1g-dev; \
     pie install xdebug/xdebug; \
+    pie install noisebynorthwest/php-spx; \
+    apt-get remove --purge -y zlib1g-dev; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.2-debug
+++ b/php/Dockerfile-8.2-debug
@@ -18,4 +18,7 @@ RUN set -eux; \
     pie install xdebug/xdebug; \
     pie install noisebynorthwest/php-spx; \
     apt-get remove --purge -y zlib1g-dev; \
-    rm -rf /var/tmp/* /tmp/*;
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;

--- a/php/Dockerfile-8.2-debug
+++ b/php/Dockerfile-8.2-debug
@@ -14,7 +14,7 @@ ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install Xdebug
+# Install Xdebug and SPX
 RUN set -eux; \
     apt-get update; \
     apt-get install --no-install-recommends -y zlib1g-dev; \

--- a/php/Dockerfile-8.2-debug
+++ b/php/Dockerfile-8.2-debug
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+
 FROM jakubboucek/lamp-devstack-php:8.2
 
 LABEL org.label-schema.name="PHP 8.2 (Apache module + Xdebug)"
@@ -22,3 +25,10 @@ RUN set -eux; \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
     rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
+
+# Configure OPcache
+ENV PHP_SPX_ENABLED=0
+ENV PHP_SPX_HTTP_KEY="dev"
+ENV PHP_SPX_HTTP_IP_WHITELIST="*"
+
+COPY spx.ini /usr/local/etc/php/conf.d/spx.ini

--- a/php/Dockerfile-8.3-debug
+++ b/php/Dockerfile-8.3-debug
@@ -13,5 +13,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y zlib1g-dev; \
     pie install xdebug/xdebug; \
+    pie install noisebynorthwest/php-spx; \
+    apt-get remove --purge -y zlib1g-dev; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.3-debug
+++ b/php/Dockerfile-8.3-debug
@@ -18,4 +18,7 @@ RUN set -eux; \
     pie install xdebug/xdebug; \
     pie install noisebynorthwest/php-spx; \
     apt-get remove --purge -y zlib1g-dev; \
-    rm -rf /var/tmp/* /tmp/*;
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;

--- a/php/Dockerfile-8.3-debug
+++ b/php/Dockerfile-8.3-debug
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+
 FROM jakubboucek/lamp-devstack-php:8.3
 
 LABEL org.label-schema.name="PHP 8.3 (Apache module + Xdebug)"
@@ -22,3 +25,10 @@ RUN set -eux; \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
     rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
+
+# Configure OPcache
+ENV PHP_SPX_ENABLED=0
+ENV PHP_SPX_HTTP_KEY="dev"
+ENV PHP_SPX_HTTP_IP_WHITELIST="*"
+
+COPY spx.ini /usr/local/etc/php/conf.d/spx.ini

--- a/php/Dockerfile-8.3-debug
+++ b/php/Dockerfile-8.3-debug
@@ -14,7 +14,7 @@ ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install Xdebug
+# Install Xdebug and SPX
 RUN set -eux; \
     apt-get update; \
     apt-get install --no-install-recommends -y zlib1g-dev; \

--- a/php/Dockerfile-8.4-debug
+++ b/php/Dockerfile-8.4-debug
@@ -13,5 +13,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y zlib1g-dev; \
     pie install xdebug/xdebug; \
+    pie install noisebynorthwest/php-spx; \
+    apt-get remove --purge -y zlib1g-dev; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.4-debug
+++ b/php/Dockerfile-8.4-debug
@@ -18,4 +18,7 @@ RUN set -eux; \
     pie install xdebug/xdebug; \
     pie install noisebynorthwest/php-spx; \
     apt-get remove --purge -y zlib1g-dev; \
-    rm -rf /var/tmp/* /tmp/*;
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;

--- a/php/Dockerfile-8.4-debug
+++ b/php/Dockerfile-8.4-debug
@@ -14,7 +14,7 @@ ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install Xdebug
+# Install Xdebug and SPX
 RUN set -eux; \
     apt-get update; \
     apt-get install --no-install-recommends -y zlib1g-dev; \

--- a/php/Dockerfile-8.4-debug
+++ b/php/Dockerfile-8.4-debug
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+
 FROM jakubboucek/lamp-devstack-php:8.4
 
 LABEL org.label-schema.name="PHP 8.4 (Apache module + Xdebug)"
@@ -22,3 +25,10 @@ RUN set -eux; \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
     rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
+
+# Configure OPcache
+ENV PHP_SPX_ENABLED=0
+ENV PHP_SPX_HTTP_KEY="dev"
+ENV PHP_SPX_HTTP_IP_WHITELIST="*"
+
+COPY spx.ini /usr/local/etc/php/conf.d/spx.ini

--- a/php/Dockerfile-8.5-debug
+++ b/php/Dockerfile-8.5-debug
@@ -13,5 +13,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xdebug
 RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y zlib1g-dev; \
     pie install xdebug/xdebug; \
+    pie install noisebynorthwest/php-spx; \
+    apt-get remove --purge -y zlib1g-dev; \
     rm -rf /var/tmp/* /tmp/*;

--- a/php/Dockerfile-8.5-debug
+++ b/php/Dockerfile-8.5-debug
@@ -18,4 +18,7 @@ RUN set -eux; \
     pie install xdebug/xdebug; \
     pie install noisebynorthwest/php-spx; \
     apt-get remove --purge -y zlib1g-dev; \
-    rm -rf /var/tmp/* /tmp/*;
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;

--- a/php/Dockerfile-8.5-debug
+++ b/php/Dockerfile-8.5-debug
@@ -14,7 +14,7 @@ ARG PIE_WORKING_DIRECTORY=/tmp/.pie
 # Prevent interactive block
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install Xdebug
+# Install Xdebug and SPX
 RUN set -eux; \
     apt-get update; \
     apt-get install --no-install-recommends -y zlib1g-dev; \

--- a/php/Dockerfile-8.5-debug
+++ b/php/Dockerfile-8.5-debug
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+
 FROM jakubboucek/lamp-devstack-php:8.5
 
 LABEL org.label-schema.name="PHP 8.5 (Apache module + Xdebug)"
@@ -22,3 +25,10 @@ RUN set -eux; \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
     rm -rf /var/cache/* /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/* ~/.composer/cache/*;
+
+# Configure OPcache
+ENV PHP_SPX_ENABLED=0
+ENV PHP_SPX_HTTP_KEY="dev"
+ENV PHP_SPX_HTTP_IP_WHITELIST="*"
+
+COPY spx.ini /usr/local/etc/php/conf.d/spx.ini

--- a/php/spx.ini
+++ b/php/spx.ini
@@ -1,0 +1,4 @@
+spx.http_enabled=${PHP_SPX_ENABLED}
+spx.http_key=${PHP_SPX_HTTP_KEY}
+spx.http_ip_whitelist=${PHP_SPX_HTTP_IP_WHITELIST}
+


### PR DESCRIPTION
Add the [SPX - A simple profiler for PHP](https://github.com/NoiseByNorthwest/php-spx/blob/master/README.md) to PHP debug images.

Thanks to @srigi & @JanTvrdik for [inspiration](https://www.youtube.com/watch?v=2JluEXpx6co).