### PR TITLE
mariadb: Update versions

### DIFF
--- a/build-mariadb.sh
+++ b/build-mariadb.sh
@@ -12,7 +12,7 @@ NO_PUSH=${NO_PUSH:-0}
 # Source: https://hub.docker.com/_/mariadb
 
 ### MariaDB - 10.6
-MARIADB_RELEASE=25
+MARIADB_RELEASE=26
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.6.${MARIADB_RELEASE}
     docker tag mariadb:10.6.${MARIADB_RELEASE} mariadb:10.6
@@ -34,7 +34,7 @@ if [ "${NO_PUSH}" -ne "1" ]; then
 fi
 
 ### MariaDB - 10.11
-MARIADB_RELEASE=16
+MARIADB_RELEASE=17
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:10.11.${MARIADB_RELEASE}
     docker tag mariadb:10.11.${MARIADB_RELEASE} mariadb:10.11
@@ -58,7 +58,7 @@ if [ "${NO_PUSH}" -ne "1" ]; then
 fi
 
 ### MariaDB - 11.4
-MARIADB_RELEASE=10
+MARIADB_RELEASE=11
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:11.4.${MARIADB_RELEASE}
     docker tag mariadb:11.4.${MARIADB_RELEASE} mariadb:11.4
@@ -81,7 +81,7 @@ fi
 
 
 ### MariaDB - 11.8
-MARIADB_RELEASE=6
+MARIADB_RELEASE=7
 if [ "${NO_PULL}" -ne "1" ]; then
     docker pull mariadb:11.8.${MARIADB_RELEASE}
     docker tag mariadb:11.8.${MARIADB_RELEASE} mariadb:11.8


### PR DESCRIPTION
This pull request updates the `build-mariadb.sh` script to use the latest patch releases for several MariaDB versions. No other logic changes are included.

MariaDB version updates:

* Updated the patch release for MariaDB 10.6 from `25` to `26`.
* Updated the patch release for MariaDB 10.11 from `16` to `17`.
* Updated the patch release for MariaDB 11.4 from `10` to `11`.
* Updated the patch release for MariaDB 11.8 from `6` to `7`.